### PR TITLE
Add icons to 'How We Work' steps

### DIFF
--- a/page
+++ b/page
@@ -58,6 +58,7 @@
     .how{display:grid;grid-template-columns:repeat(4,1fr);gap:22px}
     .step{background:var(--card);border:1px solid rgba(16,24,40,.06);border-radius:18px;padding:22px}
     .step .num{font-weight:800;color:var(--brand)}
+    .step svg{width:40px;height:40px;color:var(--brand);margin-bottom:12px}
     .logos{display:grid;grid-template-columns:repeat(6,1fr);gap:18px;opacity:.85}
     .logo-box{background:#fff;border:1px dashed rgba(16,24,40,.08);border-radius:14px;height:64px;display:grid;place-items:center;font-weight:700;color:#64748b}
     .cta{background:linear-gradient(180deg,#fff,#eef6ff)}
@@ -171,10 +172,10 @@
       <h2>How We Work</h2>
       <p class="lead">A transparent, data-assisted search process that keeps you informed from kickoff to signed offer.</p>
       <div class="how" style="margin-top:18px">
-        <div class="step"><div class="num">01</div><h3>Discovery</h3><p>Define success profile, must-haves, and cultural markers. Align on timeline and milestones.</p></div>
-        <div class="step"><div class="num">02</div><h3>Mapping</h3><p>Market map + longlist using AI for precision matching and human validation to remove bias.</p></div>
-        <div class="step"><div class="num">03</div><h3>Shortlist</h3><p>Top candidates with scorecards, references, and first-round notes inside a live dashboard.</p></div>
-        <div class="step"><div class="num">04</div><h3>Close</h3><p>Offer strategy, expectation alignment, and onboarding support to ensure a strong start.</p></div>
+        <div class="step"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="16.65" y1="16.65" x2="21" y2="21"/></svg><div class="num">01</div><h3>Discovery</h3><p>Define success profile, must-haves, and cultural markers. Align on timeline and milestones.</p></div>
+        <div class="step"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6l5-2 6 2 7-2v14l-5 2-6-2-7 2V6z"/><path d="M8 4v14"/><path d="M14 6v14"/></svg><div class="num">02</div><h3>Mapping</h3><p>Market map + longlist using AI for precision matching and human validation to remove bias.</p></div>
+        <div class="step"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 7h11"/><path d="M9 12h11"/><path d="M9 17h11"/><path d="M4 7l2 2 3-3"/><path d="M4 12l2 2 3-3"/><path d="M4 17l2 2 3-3"/></svg><div class="num">03</div><h3>Shortlist</h3><p>Top candidates with scorecards, references, and first-round notes inside a live dashboard.</p></div>
+        <div class="step"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/></svg><div class="num">04</div><h3>Close</h3><p>Offer strategy, expectation alignment, and onboarding support to ensure a strong start.</p></div>
       </div>
     </div>
   </section>

--- a/page2
+++ b/page2
@@ -95,6 +95,7 @@
     .card{background:#fafafa;border:1px solid var(--line);border-radius:var(--radius);padding:20px}
     .card h3{margin:8px 0 6px}
     .icon{width:36px;height:36px;border-radius:10px;background:linear-gradient(180deg,#eafff9,#fff);border:1px solid #d9f4ee;display:grid;place-items:center}
+    #process .card svg{width:32px;height:32px;color:var(--accent);margin-bottom:12px}
 
     /* Testimonials */
     .testis{background:#f6f8fb;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
@@ -225,10 +226,10 @@
     <h2 class="section-title">How We Work</h2>
     <p class="lead">Transparent stages with measurable outcomes, from kickoff to signed offer.</p>
     <div class="grid g-4">
-      <div class="card"><strong>01 • Discovery</strong><p>Success profile, culture signals, timeline and success criteria.</p></div>
-      <div class="card"><strong>02 • Mapping</strong><p>Market map + longlist; human validation layered on ethical AI.</p></div>
-      <div class="card"><strong>03 • Shortlist</strong><p>Structured interviews, scorecards and weekly progress reports.</p></div>
-      <div class="card"><strong>04 • Close</strong><p>Offer strategy, expectation alignment and onboarding support.</p></div>
+      <div class="card"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="16.65" y1="16.65" x2="21" y2="21"/></svg><strong>01 • Discovery</strong><p>Success profile, culture signals, timeline and success criteria.</p></div>
+      <div class="card"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6l5-2 6 2 7-2v14l-5 2-6-2-7 2V6z"/><path d="M8 4v14"/><path d="M14 6v14"/></svg><strong>02 • Mapping</strong><p>Market map + longlist; human validation layered on ethical AI.</p></div>
+      <div class="card"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 7h11"/><path d="M9 12h11"/><path d="M9 17h11"/><path d="M4 7l2 2 3-3"/><path d="M4 12l2 2 3-3"/><path d="M4 17l2 2 3-3"/></svg><strong>03 • Shortlist</strong><p>Structured interviews, scorecards and weekly progress reports.</p></div>
+      <div class="card"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/></svg><strong>04 • Close</strong><p>Offer strategy, expectation alignment and onboarding support.</p></div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Add SVG icon styling for each step in the "How We Work" sections.
- Introduce Discovery, Mapping, Shortlist and Close icons to both pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c90f9e34832ab909b34a77666ece