### PR TITLE
Fix zoomed images in sectors slider

### DIFF
--- a/page2
+++ b/page2
@@ -106,7 +106,7 @@
 
     .sector-slider{position:relative;overflow:hidden;margin-top:30px;height:200px;border-radius:var(--radius);box-shadow:var(--shadow)}
     .sector-track{display:flex;width:400%;height:100%;transition:transform .6s ease}
-    .sector-track img{flex:0 0 100%;object-fit:cover}
+    .sector-track img{flex:0 0 100%;object-fit:contain;width:100%;height:100%}
 
     /* Testimonials */
     .testis{background:#f6f8fb;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}


### PR DESCRIPTION
## Summary
- Prevent cropping of sector images by switching to `object-fit:contain` so the entire image appears in the slider

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c677102530832a95d9b4ec2d369a85