### PR TITLE
Trim section spacing for cleaner layout

### DIFF
--- a/page
+++ b/page
@@ -35,7 +35,7 @@
     .logo-mark{height:34px;width:34px;border-radius:9px;background:conic-gradient(from 210deg at 50% 50%, #f97316, #ef4444 35%, #3b82f6 70%, #22c55e 100%);position:relative}
     .logo-mark:after{content:"";position:absolute;inset:5px;border-radius:7px;background:#fff}
     /* HERO */
-    .hero{padding:72px 0 32px;background:linear-gradient(180deg,#ffffff, #f7fbff 60%, #f6f8fb)}
+    .hero{padding:36px 0 16px;background:linear-gradient(180deg,#ffffff, #f7fbff 60%, #f6f8fb)}
     .hero-grid{display:grid;grid-template-columns:1.2fr 1fr;gap:48px;align-items:center}
     .eyebrow{letter-spacing:.12em;text-transform:uppercase;color:#6366f1;font-weight:800;font-size:.78rem}
     .h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.1;margin:.35rem 0 1rem;font-weight:800}
@@ -48,7 +48,7 @@
     .blob{position:absolute;inset:-30px -40px -40px -30px;z-index:0;filter:blur(0.5px)}
     .card{position:relative;z-index:1;background:var(--card);border:1px solid rgba(16,24,40,.06);border-radius:20px;box-shadow:0 12px 40px rgba(2,6,23,.06);padding:18px}
     /* Sections */
-    section{padding:72px 0}
+    section{padding:36px 0}
     h2{font-size:clamp(1.25rem,2.2vw,1.9rem);margin:0 0 18px}
     .lead{color:var(--muted);max-width:62ch}
     .grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:22px}
@@ -63,7 +63,7 @@
     .cta{background:linear-gradient(180deg,#fff,#eef6ff)}
     .cta-card{display:grid;grid-template-columns:1.2fr .8fr;gap:22px;align-items:center;background:#0b1220;color:#e5edff;border-radius:22px;padding:28px}
     .cta-card .btn{background:#22c55e}
-    footer{background:#0b1220;color:#cbd5e1;padding:40px 0}
+    footer{background:#0b1220;color:#cbd5e1;padding:20px 0}
     footer a{color:#cbd5e1}
 
     /* --- Full-bleed utility to make footer stretch edge-to-edge --- */

--- a/page2
+++ b/page2
@@ -54,7 +54,7 @@
 
     /* HERO */
     .hero{position:relative;overflow:hidden}
-    .hero .inner{display:grid;grid-template-columns:1.12fr .88fr;align-items:center;gap:48px;padding-block: clamp(40px,8vw,90px)}
+    .hero .inner{display:grid;grid-template-columns:1.12fr .88fr;align-items:center;gap:48px;padding-block: clamp(20px,4vw,45px)}
     .eyebrow{font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#475569}
     h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.08;margin:.35rem 0 1rem}
     .hero p.sub{color:var(--muted);font-size:1.08rem;max-width:58ch}
@@ -87,7 +87,7 @@
     .accent{color:var(--accent)}
 
     /* Sections */
-    section{padding-block: clamp(48px, 9vw, 88px)}
+    section{padding-block: clamp(24px, 4.5vw, 44px)}
     .section-title{text-align:center;margin-bottom:8px;font-size:clamp(1.2rem,2.2vw,1.8rem)}
     .lead{color:var(--muted);text-align:center;max-width:70ch;margin:0 auto 28px}
     .grid{display:grid;gap:22px}


### PR DESCRIPTION
## Summary
- Halve hero, section, and footer padding to reduce vertical gaps on the main page
- Reduce hero and section padding clamps on the secondary page for consistent spacing

## Testing
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c694f3c5b0832ab1e5c5390fc3afa4