### PR TITLE
Use Contact Form 7 shortcode on page2

### DIFF
--- a/page2
+++ b/page2
@@ -333,15 +333,7 @@
     <h2 class="section-title"><span class="values-title">Ready to Start?</span></h2>
     <p class="lead">Tell us what success looks like, we’ll build a search around it.</p>
     <div class="grid" style="grid-template-columns:1.1fr .9fr; gap:24px;">
-      <form class="card" onsubmit="event.preventDefault(); alert('Thanks! We will get in touch shortly.');">
-        <div style="display:grid;gap:12px">
-          <input required name="name" placeholder="Your name" style="padding:12px 14px;border:1px solid var(--line);border-radius:10px">
-          <input required type="email" name="email" placeholder="Your email" style="padding:12px 14px;border:1px solid var(--line);border-radius:10px">
-          <input name="company" placeholder="Company" style="padding:12px 14px;border:1px solid var(--line);border-radius:10px">
-          <textarea rows="4" name="message" placeholder="Tell us about the role" style="padding:12px 14px;border:1px solid var(--line);border-radius:10px;resize:vertical"></textarea>
-          <button class="btn btn-primary" type="submit">Send Inquiry</button>
-        </div>
-      </form>
+      <div class="card">[contact-form-7 id="e7e9470" title="Sin título"]</div>
       <div class="card" style="display:grid;gap:10px">
         <h3>Contact</h3>
         <p class="muted">📞 +34 600 123 456<br>✉️ contact@kovacictalent.com<br>📍 Madrid · Barcelona · Santiago</p>


### PR DESCRIPTION
## Summary
- replace hardcoded contact form in page2 with Contact Form 7 shortcode

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c699559920832abe3cf566696335c3