### PR TITLE
Apply dark background with inverted button colors

### DIFF
--- a/page2
+++ b/page2
@@ -9,9 +9,9 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root{
-      --ink:#101828;
-      --muted:#667085;
-      --bg:#ffffff;
+      --ink:#ffffff;
+      --muted:#ffffff;
+      --bg:#0A212E;
       --accent:#0A212E;
       --accent-dark:#0A212E;
       --line:#ebedf0;
@@ -28,10 +28,10 @@
     img{max-width:100%;display:block}
     .container{max-width:var(--w); margin-inline:auto; padding-inline:var(--pad)}
     .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
-    .btn-primary{background:#111;color:#fff}
+    .btn-primary{background:#fff;color:#000}
     .btn-primary:hover{filter:brightness(.95)}
-    .btn-ghost{border:2px solid #111;color:#111}
-    .btn-ghost:hover{background:#111;color:#fff}
+    .btn-ghost{border:2px solid #000;background:#fff;color:#000}
+    .btn-ghost:hover{background:#000;color:#fff}
     .pill{display:inline-flex;align-items:center;gap:.5rem;color:#0f172a;background:linear-gradient(90deg,#eafcf8,#fff);border:1px solid #d9f4ee;padding:.35rem .7rem;border-radius:999px;font-weight:700;font-size:.78rem}
     .dot{width:8px;height:8px;border-radius:999px;background:#d1d5db}
     .dot.is-active{background:var(--accent)}
@@ -55,7 +55,7 @@
     /* HERO */
     .hero{position:relative;overflow:hidden}
     .hero .inner{display:grid;grid-template-columns:1.12fr .88fr;align-items:center;gap:48px;padding-block: clamp(20px,4vw,45px)}
-    .eyebrow{font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#475569}
+    .eyebrow{font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#fff}
     h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.08;margin:.35rem 0 1rem}
     .hero p.sub{color:var(--muted);font-size:1.08rem;max-width:58ch}
     .cta-row{display:flex;flex-wrap:wrap;gap:12px;margin-top:22px}
@@ -94,8 +94,9 @@
     .grid{display:grid;gap:22px}
     .g-3{grid-template-columns:repeat(3,1fr)}
     .g-4{grid-template-columns:repeat(4,1fr)}
-    .card{background:#fafafa;border:1px solid var(--line);border-radius:var(--radius);padding:20px}
+    .card{background:#fafafa;border:1px solid var(--line);border-radius:var(--radius);padding:20px;color:#0f172a}
     .card h3{margin:8px 0 6px}
+    .card p{color:#667085}
     .icon{width:36px;height:36px;border-radius:10px;background:linear-gradient(180deg,#eafff9,#fff);border:1px solid #d9f4ee;display:grid;place-items:center}
     #process .card svg,
     #process-ai .card svg{width:32px;height:32px;color:var(--accent);margin-bottom:12px}
@@ -135,16 +136,17 @@
 
     /* Testimonials */
     .testis{background:#f6f8fb;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
-    blockquote{max-width:860px;margin:0 auto;padding:0 20px;font-size:1.1rem;line-height:1.6;text-align:center;color:#0f172a}
-    cite{display:block;margin-top:10px;color:#475569;font-style:normal;font-weight:700}
+    blockquote{max-width:860px;margin:0 auto;padding:0 20px;font-size:1.1rem;line-height:1.6;text-align:center;color:#fff}
+    cite{display:block;margin-top:10px;color:#fff;font-style:normal;font-weight:700}
 
     /* Footer */
-    footer{background:#0b1220;color:#cbd5e1}
+    footer{background:var(--bg);color:#fff}
+    footer a{color:#fff}
     .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
     .newsletter{display:flex;gap:10px}
     .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
-    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800}
-    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    .newsletter button{border:none;background:#fff;color:#000;border-radius:999px;padding:12px 18px;font-weight:800}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#fff}
 
     /* Responsive */
     @media (max-width: 980px){
@@ -409,7 +411,7 @@
   <footer>
     <div class="container footer-inner">
       <div>
-        <p style="color:#94a3b8;max-width:58ch">Executive search and senior specialist recruitment across Technology and Renewable Energy. Boutique service, global reach.</p>
+        <p style="color:#fff;max-width:58ch">Executive search and senior specialist recruitment across Technology and Renewable Energy. Boutique service, global reach.</p>
       </div>
       <div>
         <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
@@ -419,7 +421,7 @@
       </div>
     </div>
     <div class="container mini">
-      © <span id="y"></span> Kovacic Talent. All rights reserved · <a href="#" style="color:#cbd5e1">Privacy</a> · <a href="#" style="color:#cbd5e1">Terms</a>
+      © <span id="y"></span> Kovacic Talent. All rights reserved · <a href="#" style="color:#fff">Privacy</a> · <a href="#" style="color:#fff">Terms</a>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary
- Switch root theme to dark navy background with white base text
- Invert button styling to white buttons with black text
- Ensure cards and footer retain readable dark-on-light text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6aca35bec832a96b964076c476620