### PR TITLE
Unify legal and feedback pages with main template styling

### DIFF
--- a/article_page
+++ b/article_page
@@ -7,22 +7,30 @@
   <meta name="description" content="Insights from Kovacic Talent's executive recruitment team." />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  
+  
   <style>
     :root{
       --ink:#101828;
       --muted:#667085;
       --bg:#ffffff;
       --accent:#0A212E;
+      --accent-dark:#0A212E;
       --line:#ebedf0;
+      --beige:#E9F0F5;
       --shadow:0 10px 30px rgba(16,24,40,.08);
       --radius:14px;
-      --pad:clamp(16px,3.2vw,28px);
-      --w:1180px;
+      --radius-lg:22px;
+      --pad: clamp(16px, 3.2vw, 28px);
+      --w: 1180px;
     }
     *{box-sizing:border-box}
-    body{margin:0;font-family:Inter,system-ui,-apple-system,"Segoe UI",Roboto,Arial;color:var(--ink);background:var(--bg);line-height:1.6}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
     a{color:inherit;text-decoration:none}
     img{max-width:100%;display:block}
+    .muted{color:var(--muted)}
     .container{max-width:var(--w);margin-inline:auto;padding-inline:var(--pad)}
     .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
     .btn-primary{background:#111;color:#fff}
@@ -30,19 +38,61 @@
     .btn-ghost{border:2px solid #111;color:#111}
     .btn-ghost:hover{background:#111;color:#fff}
 
-    .topbar{background:#111;color:#fff;font-size:.85rem}
-    .topbar .inner{display:flex;justify-content:space-between;align-items:center;height:40px}
-    .social a{opacity:.85;margin-left:14px}
-    .social a:hover{opacity:1}
-
-    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line)}
-    .nav .inner{display:flex;align-items:center;justify-content:space-between;height:66px}
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:24px;height:66px;position:relative}
     .logo{display:flex;align-items:center;gap:.6rem;font-weight:900;letter-spacing:.02em}
     .logo-img{height:36px;width:auto}
-    .menu{display:flex;gap:26px;align-items:center;flex-wrap:wrap}
-    .menu a{font-weight:600;color:#0f172a}
-    .menu a:hover{color:var(--accent)}
+    .menu-panel{display:flex;align-items:center;gap:26px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:26px;align-items:center}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease}
+    .menu a:hover{color:var(--accent-dark)}
     .nav-cta{display:flex;gap:10px;align-items:center}
+    .nav-cta .btn{white-space:nowrap}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin::before{
+      content:"";
+      width:12px;
+      height:12px;
+      display:block;
+      background:currentColor;
+      -webkit-mask:url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23000%22%20d%3D%22M22.225%200H1.771C.792%200%200%20.774%200%201.729v20.542C0%2023.226.792%2024%201.771%2024h20.451C23.2%2024%2024%2023.226%2024%2022.271V1.729C24%20.774%2023.2%200%2022.222%200h.003zM6.615%2020.452H3.558V9h3.057v11.452zM5.087%207.633a1.773%201.773%200%20110-3.546%201.773%201.773%200%20010%203.546zm15.36%2012.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851%200-2.136%201.446-2.136%202.94v5.665H10.35V9h2.93v1.561h.041c.408-.77%201.405-1.584%202.894-1.584%203.094%200%203.663%202.039%203.663%204.689v6.786z%22/%3E%3C/svg%3E') no-repeat center/contain;
+      mask:url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23000%22%20d%3D%22M22.225%200H1.771C.792%200%200%20.774%200%201.729v20.542C0%2023.226.792%2024%201.771%2024h20.451C23.2%2024%2024%2023.226%2024%2022.271V1.729C24%20.774%2023.2%200%2022.222%200h.003zM6.615%2020.452H3.558V9h3.057v11.452zM5.087%207.633a1.773%201.773%200%20110-3.546%201.773%201.773%200%20010%203.546zm15.36%2012.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851%200-2.136%201.446-2.136%202.94v5.665H10.35V9h2.93v1.561h.041c.408-.77%201.405-1.584%202.894-1.584%203.094%200%203.663%202.039%203.663%204.689v6.786z%22/%3E%3C/svg%3E') no-repeat center/contain;
+    }
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
 
     main.article-section{padding-block:clamp(40px,8vw,80px);background:linear-gradient(180deg,#f8fafc,#fff 60%)}
     .article-frame{background:#fff;border:1px solid var(--line);border-radius:24px;box-shadow:var(--shadow);padding:clamp(24px,5vw,56px);max-width:860px;margin-inline:auto}
@@ -72,22 +122,25 @@
     .article-frame .wp-block-post-content .alignright{float:right;margin:0 0 1em 1.4em;max-width:50%}
     .article-frame .wp-block-post-content iframe{width:100%;min-height:320px;border:none;border-radius:18px}
 
-    footer{background:#0f172a;color:#e2e8f0;padding:40px 0 30px;margin-top:clamp(40px,6vw,80px)}
+    footer{background:#0b1220;color:#cbd5e1;padding:40px 0 30px;margin-top:clamp(40px,6vw,80px)}
     .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
     .newsletter{display:flex;gap:10px}
     .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
     .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800;cursor:pointer}
-    .mini{margin-top:26px;font-size:.85rem;color:#94a3b8}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
     .mini a{color:#cbd5e1}
 
-    @media (max-width:960px){
-      .topbar .inner{flex-direction:column;height:auto;padding-block:8px;gap:4px;text-align:center}
-      .nav .inner{flex-wrap:wrap;gap:16px;justify-content:center;height:auto;padding-block:10px}
-      .menu{justify-content:center}
-      .nav-cta{flex-direction:column;width:100%}
-      .nav-cta .btn{width:100%;text-align:center;justify-content:center}
-      .article-frame{padding:clamp(20px,6vw,40px)}
-      .footer-inner{grid-template-columns:1fr}
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+      .footer-inner{grid-template-columns:1fr;text-align:center}
+      .newsletter{justify-content:center}
     }
 
     @media (max-width:640px){
@@ -103,35 +156,28 @@
   </style>
 </head>
 <body>
-
-  <!-- Topbar -->
-  <div class="topbar">
-    <div class="container inner">
-      <div>📞 +34 600 123 456 · ✉️ contact@kovacictalent.com</div>
-      <div class="social">
-        <a href="https://linkedin.com/company/kovacic-executive-talent"
-           aria-label="LinkedIn"
-           target="_blank"
-           rel="noopener noreferrer">in</a>
-      </div>
-    </div>
-  </div>
-
   <!-- Navigation -->
   <nav class="nav" aria-label="Primary navigation">
     <div class="container inner">
-      <a class="logo" href="#"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
-      <div class="menu">
-        <a href="#sectors">Sectors</a>
-        <a href="#About">About us</a>
-        <a href="#Values">Our Values</a>
-        <a href="#process">How We Work</a>
-        <a href="#processes">Latest processes</a>
-        <a href="#contact">Contact</a>
-      </div>
-      <div class="nav-cta">
-        <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Submit CV</a>
-        <a class="btn btn-primary" href="#contact">Request a Call</a>
+      <a class="logo" href="http://www.kovacictalent.com"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menu</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="http://www.kovacictalent.com#sectors">Sectors</a>
+          <a href="http://www.kovacictalent.com#About">About us</a>
+          <a href="http://www.kovacictalent.com#Values">Our Values</a>
+          <a href="http://www.kovacictalent.com#process">How We Work</a>
+          <a href="http://www.kovacictalent.com#processes">Latest processes</a>
+          <a href="http://www.kovacictalent.com#contact">Contact</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Submit CV</a>
+          <a class="btn btn-primary" href="http://www.kovacictalent.com#contact">Request a Call</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent on LinkedIn (opens in a new tab)"></a>
+        </div>
       </div>
     </div>
   </nav>
@@ -173,6 +219,33 @@
     if(yearTarget){
       yearTarget.textContent = new Date().getFullYear();
     }
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
   </script>
 </body>
 </html>

--- a/cv_feedback
+++ b/cv_feedback
@@ -24,9 +24,11 @@
     }
     *{box-sizing:border-box}
     html,body{height:100%;overflow-x:hidden}
-    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink); background:var(--bg)}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
     a{color:inherit;text-decoration:none}
     img{max-width:100%;display:block}
+    .muted{color:var(--muted)}
     .container{max-width:var(--w); margin-inline:auto; padding-inline:var(--pad)}
     .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
     .btn-primary{background:#111;color:#fff}
@@ -36,22 +38,62 @@
     .pill{display:inline-flex;align-items:center;gap:.5rem;color:#0f172a;background:linear-gradient(90deg,#eafcf8,#fff);border:1px solid #d9f4ee;padding:.35rem .7rem;border-radius:999px;font-weight:700;font-size:.78rem}
     .dot{width:8px;height:8px;border-radius:999px;background:#d1d5db}
     .dot.is-active{background:var(--accent)}
-
-    /* Topbar */
-    .topbar{background:#111;color:#fff;font-size:.85rem}
-    .topbar .inner{display:flex;justify-content:space-between;align-items:center;height:40px}
-    .social a{opacity:.85;margin-left:14px}
-    .social a:hover{opacity:1}
-
     /* Navbar */
-    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line)}
-    .nav .inner{display:flex;align-items:center;justify-content:space-between;height:66px}
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:24px;height:66px;position:relative}
     .logo{display:flex;align-items:center;gap:.6rem;font-weight:900;letter-spacing:.02em}
     .logo-img{height:36px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:26px;margin-left:auto;position:relative}
     .menu{display:flex;gap:26px;align-items:center}
-    .menu a{font-weight:600;color:#0f172a}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease}
     .menu a:hover{color:var(--accent-dark)}
     .nav-cta{display:flex;gap:10px;align-items:center}
+    .nav-cta .btn{white-space:nowrap}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin::before{
+      content:"";
+      width:12px;
+      height:12px;
+      display:block;
+      background:currentColor;
+      -webkit-mask:url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23000%22%20d%3D%22M22.225%200H1.771C.792%200%200%20.774%200%201.729v20.542C0%2023.226.792%2024%201.771%2024h20.451C23.2%2024%2024%2023.226%2024%2022.271V1.729C24%20.774%2023.2%200%2022.222%200h.003zM6.615%2020.452H3.558V9h3.057v11.452zM5.087%207.633a1.773%201.773%200%20110-3.546%201.773%201.773%200%20010%203.546zm15.36%2012.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851%200-2.136%201.446-2.136%202.94v5.665H10.35V9h2.93v1.561h.041c.408-.77%201.405-1.584%202.894-1.584%203.094%200%203.663%202.039%203.663%204.689v6.786z%22/%3E%3C/svg%3E') no-repeat center/contain;
+      mask:url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23000%22%20d%3D%22M22.225%200H1.771C.792%200%200%20.774%200%201.729v20.542C0%2023.226.792%2024%201.771%2024h20.451C23.2%2024%2024%2023.226%2024%2022.271V1.729C24%20.774%2023.2%200%2022.222%200h.003zM6.615%2020.452H3.558V9h3.057v11.452zM5.087%207.633a1.773%201.773%200%20110-3.546%201.773%201.773%200%20010%203.546zm15.36%2012.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851%200-2.136%201.446-2.136%202.94v5.665H10.35V9h2.93v1.561h.041c.408-.77%201.405-1.584%202.894-1.584%203.094%200%203.663%202.039%203.663%204.689v6.786z%22/%3E%3C/svg%3E') no-repeat center/contain;
+    }
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
 
     /* CV Feedback Styles */
     .kcvf *{box-sizing:border-box}
@@ -122,49 +164,69 @@
     .kcvf-shortcode{display:none;margin-top:14px; padding:16px; border-radius:12px; background:#f4f6f8; border:1px dashed rgba(10,33,46,.25)}
     .kcvf-shortcode strong{color:var(--ink)}
 
+    footer{background:#0b1220;color:#cbd5e1;padding:40px 0 30px;margin-top:clamp(40px,6vw,80px)}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800;cursor:pointer}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    .mini a{color:#cbd5e1}
+
     .kcvf-faq{margin-top:42px; display:grid; grid-template-columns:repeat(2,1fr); gap:18px}
     .kcvf-faq .q{
       background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:18px;box-shadow:0 10px 18px rgba(16,24,40,.05);
     }
     .kcvf-faq h4{margin:.2rem 0 .3rem}
 
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+      .footer-inner{grid-template-columns:1fr;text-align:center}
+      .newsletter{justify-content:center}
+    }
+
     @media (max-width: 900px){
       .kcvf-hero, .kcvf-steps{grid-template-columns:1fr}
       .kcvf-grid{grid-template-columns:1fr; gap:14px}
       .kcvf-faq{grid-template-columns:1fr}
     }
+
+    @media (max-width:640px){
+      .newsletter{flex-direction:column}
+      .newsletter input,
+      .newsletter button{width:100%}
+    }
   </style>
 </head>
 <body>
-
-  <!-- Topbar -->
-  <div class="topbar">
-    <div class="container inner">
-      <div>📞 +34 600 123 456 · ✉️ contact@kovacictalent.com</div>
-      <div class="social">
-<a href="https://linkedin.com/company/kovacic-executive-talent"
-   aria-label="LinkedIn"
-   target="_blank"
-   rel="noopener noreferrer">in</a>
-      </div>
-    </div>
-  </div>
-
   <!-- Navigation -->
   <nav class="nav" aria-label="Primary navigation">
     <div class="container inner">
       <a class="logo" href="http://www.kovacictalent.com"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
-      <div class="menu">
-        <a href="http://www.kovacictalent.com#sectors">Sectors</a>
-        <a href="http://www.kovacictalent.com#About">About us</a>
-        <a href="http://www.kovacictalent.com#Values">Our Values</a>
-        <a href="http://www.kovacictalent.com#process">How We Work</a>
-        <a href="http://www.kovacictalent.com#processes">Latest processes</a>
-        <a href="http://www.kovacictalent.com#contact">Contact</a>
-      </div>
-      <div class="nav-cta">
-        <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Submit CV</a>
-        <a class="btn btn-primary" href="#contact">Request a Call</a>
+      <button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menu</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="http://www.kovacictalent.com#sectors">Sectors</a>
+          <a href="http://www.kovacictalent.com#About">About us</a>
+          <a href="http://www.kovacictalent.com#Values">Our Values</a>
+          <a href="http://www.kovacictalent.com#process">How We Work</a>
+          <a href="http://www.kovacictalent.com#processes">Latest processes</a>
+          <a href="http://www.kovacictalent.com#contact">Contact</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Submit CV</a>
+          <a class="btn btn-primary" href="http://www.kovacictalent.com#contact">Request a Call</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent on LinkedIn (opens in a new tab)"></a>
+        </div>
       </div>
     </div>
   </nav>
@@ -284,19 +346,67 @@
     </div>
   </main>
 
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Executive search and senior specialist recruitment across Technology and Renewable Energy. Boutique service, global reach.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
+          <input type="email" required placeholder="Subscribe with your email">
+          <button type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. All rights reserved · <a href="#">Privacy</a> · <a href="#">Terms</a>
+    </div>
+  </footer>
+
   <script>
-  document.addEventListener('DOMContentLoaded', function(){
-    const btn = document.getElementById('toggle-cv-form');
-    const form = document.getElementById('cv-form');
-    if(btn && form){
-      btn.addEventListener('click', function(){
+    const yearTarget = document.getElementById('y');
+    if(yearTarget){
+      yearTarget.textContent = new Date().getFullYear();
+    }
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const btn = document.getElementById('toggle-cv-form');
+      const form = document.getElementById('cv-form');
+      if(!btn || !form) return;
+      btn.addEventListener('click', () => {
         const open = form.style.display === 'block';
         form.style.display = open ? 'none' : 'block';
         btn.setAttribute('aria-expanded', String(!open));
         btn.textContent = open ? 'Register CV' : 'Hide form';
       });
-    }
-  });
+    });
   </script>
 </body>
 </html>

--- a/page
+++ b/page
@@ -3,249 +3,238 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Rocket — AI-Enhanced Recruiting</title>
+  <title>Kovacic Talent — Terms & Policies</title>
+  <meta name="description" content="Review the terms, policies, and legal notices for Kovacic Talent." />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root{
-      --bg:#f6f8fb;
-      --card:#ffffff;
       --ink:#101828;
       --muted:#667085;
-      --brand:#3B82F6; /* primary */
-      --brand-ink:#0B4FD6;
-      --ring: rgba(59,130,246,.35);
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad: clamp(16px, 3.2vw, 28px);
+      --w: 1180px;
     }
     *{box-sizing:border-box}
-    html,body{margin:0;height:100%;scroll-behavior:smooth}
-    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,"Apple Color Emoji","Segoe UI Emoji"; color:var(--ink); background:var(--bg)}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
     a{color:inherit;text-decoration:none}
-    .container{max-width:1120px;margin-inline:auto;padding:0 20px}
-    .btn{display:inline-flex;align-items:center;gap:.5rem;background:var(--brand);color:#fff;border:none;border-radius:12px;padding:.9rem 1.15rem;font-weight:600;box-shadow:0 8px 20px rgba(59,130,246,.25);transition:.2s}
-    .btn:hover{transform:translateY(-1px);filter:saturate(1.05)}
-    .btn.alt{background:#fff;color:var(--brand);border:1px solid rgba(16,24,40,.08)}
-    .chip{display:inline-flex;align-items:center;gap:.5rem;background:#eef2ff;color:#4338ca;font-weight:600;border-radius:999px;padding:.35rem .7rem;font-size:.75rem}
-    /* NAV */
-    .nav{position:sticky;top:0;z-index:50;background:rgba(255,255,255,.7);backdrop-filter:saturate(180%) blur(8px);border-bottom:1px solid rgba(16,24,40,.06)}
-    .nav-inner{display:flex;align-items:center;justify-content:space-between;height:72px}
-    .nav ul{display:flex;gap:24px;list-style:none;margin:0;padding:0}
-    .nav a{color:#334155;font-weight:600}
-    .nav a:hover{color:var(--brand)}
-    .logo{display:flex;align-items:center;gap:.6rem;font-weight:800}
-    .logo-mark{height:34px;width:34px;border-radius:9px;background:conic-gradient(from 210deg at 50% 50%, #f97316, #ef4444 35%, #3b82f6 70%, #22c55e 100%);position:relative}
-    .logo-mark:after{content:"";position:absolute;inset:5px;border-radius:7px;background:#fff}
-    /* HERO */
-    .hero{padding:72px 0 32px;background:linear-gradient(180deg,#ffffff, #f7fbff 60%, #f6f8fb)}
-    .hero-grid{display:grid;grid-template-columns:1.2fr 1fr;gap:48px;align-items:center}
-    .eyebrow{letter-spacing:.12em;text-transform:uppercase;color:#6366f1;font-weight:800;font-size:.78rem}
-    .h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.1;margin:.35rem 0 1rem;font-weight:800}
-    .sub{color:var(--muted);font-size:1.05rem;max-width:55ch}
-    .cta-row{display:flex;gap:12px;flex-wrap:wrap;margin-top:22px}
-    .stats{display:flex;gap:24px;margin-top:28px;color:#334155}
-    .stat{background:var(--card);padding:14px 16px;border-radius:14px;border:1px solid rgba(16,24,40,.06)}
-    /* Illustration */
-    .illu-wrap{position:relative}
-    .blob{position:absolute;inset:-30px -40px -40px -30px;z-index:0;filter:blur(0.5px)}
-    .card{position:relative;z-index:1;background:var(--card);border:1px solid rgba(16,24,40,.06);border-radius:20px;box-shadow:0 12px 40px rgba(2,6,23,.06);padding:18px}
-    /* Sections */
-    section{padding:72px 0}
-    h2{font-size:clamp(1.25rem,2.2vw,1.9rem);margin:0 0 18px}
-    .lead{color:var(--muted);max-width:62ch}
-    .grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:22px}
-    .service{background:var(--card);border:1px solid rgba(16,24,40,.06);border-radius:18px;padding:22px}
-    .service h3{margin:6px 0 8px}
-    .service p{color:var(--muted);margin:0}
-    .how{display:grid;grid-template-columns:repeat(4,1fr);gap:22px}
-    .step{background:var(--card);border:1px solid rgba(16,24,40,.06);border-radius:18px;padding:22px}
-    .step .num{font-weight:800;color:var(--brand)}
-    .logos{display:grid;grid-template-columns:repeat(6,1fr);gap:18px;opacity:.85}
-    .logo-box{background:#fff;border:1px dashed rgba(16,24,40,.08);border-radius:14px;height:64px;display:grid;place-items:center;font-weight:700;color:#64748b}
-    .cta{background:linear-gradient(180deg,#fff,#eef6ff)}
-    .cta-card{display:grid;grid-template-columns:1.2fr .8fr;gap:22px;align-items:center;background:#0b1220;color:#e5edff;border-radius:22px;padding:28px}
-    .cta-card .btn{background:#22c55e}
-    footer{background:#0b1220;color:#cbd5e1;padding:40px 0}
-    footer a{color:#cbd5e1}
+    img{max-width:100%;display:block}
+    .muted{color:var(--muted)}
+    .container{max-width:var(--w);margin-inline:auto;padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
 
-    /* --- Full-bleed utility to make footer stretch edge-to-edge --- */
-    .full-bleed{
-      width:100vw;
-      margin-left:calc(50% - 50vw);
-      margin-right:calc(50% - 50vw);
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:24px;height:66px;position:relative}
+    .logo{display:flex;align-items:center;gap:.6rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:36px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:26px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:26px;align-items:center}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:10px;align-items:center}
+    .nav-cta .btn{white-space:nowrap}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
     }
-    /* Prevent horizontal scrollbar on some mobile browsers */
-    html, body { overflow-x: hidden; }
+    .nav-cta .nav-linkedin::before{
+      content:"";
+      width:12px;
+      height:12px;
+      display:block;
+      background:currentColor;
+      -webkit-mask:url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23000%22%20d%3D%22M22.225%200H1.771C.792%200%200%20.774%200%201.729v20.542C0%2023.226.792%2024%201.771%2024h20.451C23.2%2024%2024%2023.226%2024%2022.271V1.729C24%20.774%2023.2%200%2022.222%200h.003zM6.615%2020.452H3.558V9h3.057v11.452zM5.087%207.633a1.773%201.773%200%20110-3.546%201.773%201.773%200%20010%203.546zm15.36%2012.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851%200-2.136%201.446-2.136%202.94v5.665H10.35V9h2.93v1.561h.041c.408-.77%201.405-1.584%202.894-1.584%203.094%200%203.663%202.039%203.663%204.689v6.786z%22/%3E%3C/svg%3E') no-repeat center/contain;
+      mask:url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23000%22%20d%3D%22M22.225%200H1.771C.792%200%200%20.774%200%201.729v20.542C0%2023.226.792%2024%201.771%2024h20.451C23.2%2024%2024%2023.226%2024%2022.271V1.729C24%20.774%2023.2%200%2022.222%200h.003zM6.615%2020.452H3.558V9h3.057v11.452zM5.087%207.633a1.773%201.773%200%20110-3.546%201.773%201.773%200%20010%203.546zm15.36%2012.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851%200-2.136%201.446-2.136%202.94v5.665H10.35V9h2.93v1.561h.041c.408-.77%201.405-1.584%202.894-1.584%203.094%200%203.663%202.039%203.663%204.689v6.786z%22/%3E%3C/svg%3E') no-repeat center/contain;
+    }
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
 
-    /* Responsive */
-    @media (max-width: 980px){
-      .hero-grid{grid-template-columns:1fr}
-      .cta-card{grid-template-columns:1fr}
-      .grid-3{grid-template-columns:1fr 1fr}
-      .how{grid-template-columns:1fr 1fr}
-      .logos{grid-template-columns:1fr 1fr 1fr}
+    main.page-section{padding-block:clamp(40px,8vw,80px);background:linear-gradient(180deg,#f8fafc,#fff 60%)}
+    .page-hero{text-align:center;margin-bottom:clamp(24px,5vw,40px)}
+    .page-hero .pill{display:inline-flex;align-items:center;gap:.5rem;color:#0f172a;background:linear-gradient(90deg,#eafcf8,#fff);border:1px solid #d9f4ee;padding:.35rem .7rem;border-radius:999px;font-weight:700;font-size:.78rem}
+    .page-frame{background:#fff;border:1px solid var(--line);border-radius:24px;box-shadow:var(--shadow);padding:clamp(24px,4.5vw,56px);max-width:900px;margin-inline:auto}
+    .page-frame .wp-block-post-title{font-size:clamp(2rem,4.2vw,3.2rem);line-height:1.1;margin:0 0 clamp(20px,3vw,32px);text-align:center}
+    .page-frame .wp-block-post-title a{color:inherit;text-decoration:none}
+    .page-frame .wp-block-post-content{font-size:1.05rem;color:#1f2937}
+    .page-frame .wp-block-post-content > * + *{margin-top:1.35em}
+    .page-frame .wp-block-post-content h2{font-size:1.75rem;margin-top:2.2em}
+    .page-frame .wp-block-post-content h3{font-size:1.4rem;margin-top:2em}
+    .page-frame .wp-block-post-content h4{font-size:1.2rem;margin-top:1.8em}
+    .page-frame .wp-block-post-content ul,
+    .page-frame .wp-block-post-content ol{padding-left:1.4em}
+    .page-frame .wp-block-post-content li + li{margin-top:.6em}
+    .page-frame .wp-block-post-content a{color:var(--accent);text-decoration:underline;text-decoration-color:rgba(10,33,46,.3);text-decoration-thickness:2px}
+    .page-frame .wp-block-post-content table{width:100%;border-collapse:collapse}
+    .page-frame .wp-block-post-content table th,
+    .page-frame .wp-block-post-content table td{border:1px solid var(--line);padding:.75em;text-align:left}
+    .page-frame .wp-block-post-content blockquote{margin:1.8em 0;padding:1.2em 1.4em;border-left:4px solid var(--accent);background:#f8fafc;border-radius:18px;color:#0f172a;font-style:italic}
+    .page-frame .wp-block-post-content figure{margin:1.8em 0;text-align:center}
+    .page-frame .wp-block-post-content figure img{margin-inline:auto;border-radius:18px}
+    .page-frame .wp-block-post-content figure figcaption{margin-top:.75em;font-size:.95rem;color:var(--muted)}
+
+    footer{background:#0b1220;color:#cbd5e1;padding:40px 0 30px;margin-top:clamp(40px,6vw,80px)}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800;cursor:pointer}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    .mini a{color:#cbd5e1}
+
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+      .footer-inner{grid-template-columns:1fr;text-align:center}
+      .newsletter{justify-content:center}
     }
-    @media (max-width: 560px){
-      .grid-3{grid-template-columns:1fr}
-      .how{grid-template-columns:1fr}
+
+    @media (max-width:640px){
+      .page-frame{padding:clamp(20px,8vw,36px)}
+      .page-frame .wp-block-post-title{font-size:clamp(1.8rem,7vw,2.6rem)}
+      .newsletter{flex-direction:column}
+      .newsletter input,
+      .newsletter button{width:100%}
     }
   </style>
 </head>
 <body>
-  <!-- NAV -->
-  <nav class="nav">
-    <div class="container nav-inner">
-      <a href="#" class="logo" aria-label="Rocket Home">
-        <span class="logo-mark"></span>
-        <span>rocket</span>
-      </a>
-      <ul>
-        <li><a href="#how">How We Work</a></li>
-        <li><a href="#expertise">Areas of Expertise</a></li>
-        <li><a href="#about">About Us</a></li>
-        <li><a href="#insights">Insights</a></li>
-      </ul>
-      <a class="btn" href="#contact">Book a Call</a>
+  <!-- Navigation -->
+  <nav class="nav" aria-label="Primary navigation">
+    <div class="container inner">
+      <a class="logo" href="http://www.kovacictalent.com"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menu</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="http://www.kovacictalent.com#sectors">Sectors</a>
+          <a href="http://www.kovacictalent.com#About">About us</a>
+          <a href="http://www.kovacictalent.com#Values">Our Values</a>
+          <a href="http://www.kovacictalent.com#process">How We Work</a>
+          <a href="http://www.kovacictalent.com#processes">Latest processes</a>
+          <a href="http://www.kovacictalent.com#contact">Contact</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Submit CV</a>
+          <a class="btn btn-primary" href="http://www.kovacictalent.com#contact">Request a Call</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent on LinkedIn (opens in a new tab)"></a>
+        </div>
+      </div>
     </div>
   </nav>
 
-  <!-- HERO -->
-  <header class="hero">
-    <div class="container hero-grid">
+  <main class="page-section">
+    <div class="container">
+      <div class="page-hero">
+        <span class="pill">Updated Policies</span>
+      </div>
+      <div class="page-frame">
+        <!-- wp:post-title /-->
+        <div class="page-content">
+          <!-- wp:post-content /-->
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
       <div>
-        <div class="eyebrow">Recruiting + AI</div>
-        <h1 class="h1">AI-Enhanced Recruiting<br/>for High-Growth Companies</h1>
-        <p class="sub">We pair seasoned recruiters with advanced AI to help you hit ambitious hiring targets—faster, fairly, and with better long-term outcomes.</p>
-        <div class="cta-row">
-          <a class="btn" href="#contact">Book a Call</a>
-          <a class="btn alt" href="#how">See How We Work</a>
-        </div>
-        <div class="stats">
-          <div class="stat"><strong>2x</strong> faster shortlist</div>
-          <div class="stat"><strong>85%</strong> 12-mo retention</div>
-          <div class="stat"><strong>40+</strong> markets covered</div>
-        </div>
+        <p style="color:#94a3b8;max-width:58ch">Executive search and senior specialist recruitment across Technology and Renewable Energy. Boutique service, global reach.</p>
       </div>
-      <div class="illu-wrap">
-        <svg class="blob" viewBox="0 0 600 480" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <g opacity=".5">
-            <path d="M536 180c0 114-132 248-272 248S24 338 24 224 136 20 276 20s260 46 260 160Z" fill="#E7F0FF"/>
-            <circle cx="431" cy="116" r="18" fill="#DBEAFE"/>
-            <circle cx="150" cy="340" r="10" fill="#DBEAFE"/>
-          </g>
-        </svg>
-        <div class="card">
-          <!-- Astronaut + planet illustration -->
-          <svg viewBox="0 0 680 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Astronaut exploring around a planet">
-            <defs>
-              <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
-                <stop offset="0%" stop-color="#EEF2FF"/>
-                <stop offset="100%" stop-color="#E0F2FE"/>
-              </linearGradient>
-            </defs>
-            <rect x="0" y="0" width="100%" height="100%" rx="18" fill="url(#grad)"/>
-            <g stroke="#94A3B8" stroke-width="3" fill="none">
-              <ellipse cx="480" cy="200" rx="120" ry="48" fill="#F1F5F9"/>
-              <circle cx="480" cy="180" r="64" fill="#F8FAFC"/>
-              <g fill="#E2E8F0">
-                <circle cx="510" cy="168" r="10"/>
-                <circle cx="455" cy="190" r="8"/>
-                <circle cx="500" cy="205" r="7"/>
-              </g>
-              <path d="M210 220c120 60 180 100 260 70" stroke="#38BDF8" stroke-width="6"/>
-            </g>
-            <g transform="translate(100 160)">
-              <circle cx="60" cy="40" r="26" fill="#e2e8f0" stroke="#94a3b8" stroke-width="3"/>
-              <rect x="32" y="66" width="56" height="56" rx="12" fill="#fff" stroke="#94a3b8" stroke-width="3"/>
-              <rect x="44" y="86" width="32" height="10" rx="4" fill="#93c5fd"/>
-              <path d="M32 122c-10 18-18 36-1 44 18 8 30-11 37-24 4-8 8-15 12-22" fill="none" stroke="#94a3b8" stroke-width="3"/>
-              <path d="M88 122c10 18 18 36 1 44-18 8-30-11-37-24" fill="none" stroke="#94a3b8" stroke-width="3"/>
-            </g>
-          </svg>
-        </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
+          <input type="email" required placeholder="Subscribe with your email">
+          <button type="submit">Subscribe</button>
+        </form>
       </div>
     </div>
-  </header>
-
-  <!-- HOW WE WORK -->
-  <section id="how">
-    <div class="container">
-      <h2>How We Work</h2>
-      <p class="lead">A transparent, data-assisted search process that keeps you informed from kickoff to signed offer.</p>
-      <div class="how" style="margin-top:18px">
-        <div class="step"><div class="num">01</div><h3>Discovery</h3><p>Define success profile, must-haves, and cultural markers. Align on timeline and milestones.</p></div>
-        <div class="step"><div class="num">02</div><h3>Mapping</h3><p>Market map + longlist using AI for precision matching and human validation to remove bias.</p></div>
-        <div class="step"><div class="num">03</div><h3>Shortlist</h3><p>Top candidates with scorecards, references, and first-round notes inside a live dashboard.</p></div>
-        <div class="step"><div class="num">04</div><h3>Close</h3><p>Offer strategy, expectation alignment, and onboarding support to ensure a strong start.</p></div>
-      </div>
-    </div>
-  </section>
-
-  <!-- EXPERTISE -->
-  <section id="expertise" style="padding-top:0">
-    <div class="container">
-      <h2>Areas of Expertise</h2>
-      <p class="lead">From technology scale-ups to renewable energy leaders—we place critical roles that move the needle.</p>
-      <div class="grid-3" style="margin-top:18px">
-        <div class="service"><div class="chip">Executive & Product</div><h3>Leadership & Product</h3><p>C-level, VP/Director, Product & Delivery leadership for growth and transformation.</p></div>
-        <div class="service"><div class="chip">Data & Engineering</div><h3>Technology</h3><p>Software, Data, Cloud, Security, and Platform roles across EMEA & LATAM.</p></div>
-        <div class="service"><div class="chip">Energy</div><h3>Renewables</h3><p>Solar, Wind, BESS, and Grid roles including Development, EPC, and Operations.</p></div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ABOUT -->
-  <section id="about">
-    <div class="container">
-      <h2>About Us</h2>
-      <p class="lead">We’re a boutique team of senior recruiters and researchers who combine rigorous search methods with ethical AI tooling. Human judgment first—amplified by technology.</p>
-      <div class="logos" style="margin-top:22px">
-        <div class="logo-box">Client A</div>
-        <div class="logo-box">Client B</div>
-        <div class="logo-box">Client C</div>
-        <div class="logo-box">Client D</div>
-        <div class="logo-box">Client E</div>
-        <div class="logo-box">Client F</div>
-      </div>
-    </div>
-  </section>
-
-  <!-- INSIGHTS -->
-  <section id="insights" style="padding-top:0">
-    <div class="container">
-      <h2>Insights</h2>
-      <p class="lead">Guides, market notes, and case studies.</p>
-      <div class="grid-3" style="margin-top:18px">
-        <article class="service"><h3>Scorecards that predict success</h3><p>How to design role scorecards that correlate with performance in the first 180 days.</p></article>
-        <article class="service"><h3>Hiring Staff+ Engineers</h3><p>Signals that separate Staff/Principal engineers from strong seniors in interviews.</p></article>
-        <article class="service"><h3>LATAM Renewables Talent</h3><p>Where to find world-class Grid, BESS, and Solar experts in competitive markets.</p></article>
-      </div>
-    </div>
-  </section>
-
-  <!-- CTA -->
-  <section id="contact" class="cta">
-    <div class="container">
-      <div class="cta-card">
-        <div>
-          <h2 style="margin:0 0 8px">Ready to accelerate your next hire?</h2>
-          <p style="margin:0;color:#94a3b8">Tell us what success looks like—we’ll bring you a shortlist you’ll want to hire from.</p>
-        </div>
-        <div style="text-align:right">
-          <a class="btn" href="#">Book a Call</a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- FOOTER -->
-  <footer class="full-bleed">
-    <div class="container" style="display:grid;grid-template-columns:1fr auto;gap:18px;align-items:center">
-      <div>&copy; <span id="y"></span> Rocket Recruiting. All rights reserved.</div>
-      <div style="display:flex;gap:16px"><a href="#">Privacy</a><a href="#">Terms</a><a href="#">Contact</a></div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. All rights reserved · <a href="#">Privacy</a> · <a href="#">Terms</a>
     </div>
   </footer>
 
   <script>
-    document.getElementById('y').textContent = new Date().getFullYear()
+    const yearTarget = document.getElementById('y');
+    if(yearTarget){
+      yearTarget.textContent = new Date().getFullYear();
+    }
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the generic Terms page to reuse the page2 header, typography, and content frame while keeping WordPress content placeholders
- add the shared newsletter footer block from page2 to the CV feedback template and hook up the dynamic copyright year
- point the article and CV feedback navigation links back to the main site sections so the CTA destinations stay consistent

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca02ae9ef0832aaf986e6ccdc9db79