### PR TITLE
Add language switcher plugin with Spanish translation support

### DIFF
--- a/article_page_es.html
+++ b/article_page_es.html
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent — Artículo</title>
+  <meta name="description" content="Perspectivas del equipo de reclutamiento ejecutivo de Kovacic Talent." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad:clamp(16px,3.2vw,28px);
+      --w:1180px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    body.cookie-modal-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    .muted{color:var(--muted)}
+    .container{max-width:var(--w);margin-inline:auto;padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{width:12px;height:12px;display:block}
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    main.article-section{padding-block:clamp(40px,8vw,80px);background:linear-gradient(180deg,#f8fafc,#fff 60%)}
+    .article-frame{background:#fff;border:1px solid var(--line);border-radius:24px;box-shadow:var(--shadow);padding:clamp(24px,5vw,56px);max-width:860px;margin-inline:auto}
+    .article-frame .wp-block-post-title{font-size:clamp(2rem,4.5vw,3.4rem);line-height:1.1;margin:0 0 clamp(12px,2vw,24px)}
+    .article-frame .wp-block-post-title a{color:inherit;text-decoration:none}
+    .article-frame .wp-block-post-featured-image{margin-bottom:clamp(20px,3vw,40px);border-radius:20px;overflow:hidden}
+    .article-frame .wp-block-post-featured-image img{width:100%;height:auto;display:block}
+    .article-frame .wp-block-post-content{font-size:1.05rem;color:#1f2937;margin-top:clamp(20px,3vw,32px)}
+    .article-frame .wp-block-post-content > * + *{margin-top:1.35em}
+    .article-frame .wp-block-post-content h2{font-size:1.75rem;margin-top:2.2em}
+    .article-frame .wp-block-post-content h3{font-size:1.4rem;margin-top:2em}
+    .article-frame .wp-block-post-content h4{font-size:1.2rem;margin-top:1.8em}
+    .article-frame .wp-block-post-content img{border-radius:18px}
+    .article-frame .wp-block-post-content blockquote{margin:1.8em 0;padding:1.2em 1.4em;border-left:4px solid var(--accent);background:#f8fafc;border-radius:18px;color:#0f172a;font-style:italic}
+    .article-frame .wp-block-post-content ul,
+    .article-frame .wp-block-post-content ol{padding-left:1.4em}
+    .article-frame .wp-block-post-content li + li{margin-top:.6em}
+    .article-frame .wp-block-post-content a{color:var(--accent);text-decoration:underline;text-decoration-color:rgba(10,33,46,.3);text-decoration-thickness:2px}
+    .article-frame .wp-block-post-content table{width:100%;border-collapse:collapse}
+    .article-frame .wp-block-post-content table th,
+    .article-frame .wp-block-post-content table td{border:1px solid var(--line);padding:.75em;text-align:left}
+    .article-frame .wp-block-post-content figure{margin:1.8em 0;text-align:center}
+    .article-frame .wp-block-post-content figure img{margin-inline:auto}
+    .article-frame .wp-block-post-content figure figcaption{margin-top:.75em;font-size:.95rem;color:var(--muted)}
+    .article-frame .wp-block-post-content .aligncenter{margin:1.5em auto;display:block}
+    .article-frame .wp-block-post-content .alignleft{float:left;margin:0 1.4em 1em 0;max-width:50%}
+    .article-frame .wp-block-post-content .alignright{float:right;margin:0 0 1em 1.4em;max-width:50%}
+    .article-frame .wp-block-post-content iframe{width:100%;min-height:320px;border:none;border-radius:18px}
+    .article-cta{margin-top:clamp(28px,4.5vw,40px);display:flex;justify-content:center}
+
+    footer{background:#0b1220;color:#cbd5e1;padding-block:44px 28px;margin-top:clamp(40px,6vw,80px)}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800;cursor:pointer}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    footer a{color:#cbd5e1}
+
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+      .footer-inner{grid-template-columns:1fr;text-align:center}
+      .newsletter{justify-content:center}
+    }
+
+    @media (max-width:640px){
+      main.article-section{padding-block:clamp(28px,12vw,60px)}
+      .article-frame .wp-block-post-title{font-size:clamp(1.8rem,7vw,2.6rem)}
+      .article-frame .wp-block-post-featured-image{margin-bottom:20px}
+      .newsletter{flex-direction:column}
+      .newsletter input,
+      .newsletter button{width:100%}
+      .article-frame .wp-block-post-content .alignleft,
+      .article-frame .wp-block-post-content .alignright{float:none;margin:1.5em auto;max-width:100%}
+      .article-frame .wp-block-post-content iframe{min-height:240px}
+    }
+  </style>
+</head>
+<body>
+  <nav class="nav" aria-label="Navegación principal">
+    <div class="container inner">
+      <a class="logo" href="https://kovacictalent.com/"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Logotipo de Kovacic Talent" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Abrir o cerrar la navegación" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menú</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="https://kovacictalent.com/#sectors">Sectores</a>
+          <a href="https://kovacictalent.com/#About">Sobre nosotros</a>
+          <a href="https://kovacictalent.com/#Values">Nuestros valores</a>
+          <a href="https://kovacictalent.com/#process">Cómo trabajamos</a>
+          <a href="https://kovacictalent.com/#processes">Procesos</a>
+          <a href="https://kovacictalent.com/#contact">Contacto</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Enviar CV</a>
+          <a class="btn btn-primary" href="https://kovacictalent.com/#contact">Solicitar una llamada</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent en LinkedIn (se abre en una pestaña nueva)">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="article-section">
+    <div class="container">
+      <div class="article-frame">
+        <!-- wp:post-title /-->
+        <!-- wp:post-featured-image /-->
+        <!-- wp:post-content /-->
+        <div class="article-cta">
+          <a class="btn btn-primary" href="https://kovacictalent.com/contacta-con-nosotros">Enviar CV</a>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Búsqueda ejecutiva y selección de especialistas senior en Tecnología y Energía Renovable. Servicio boutique, alcance global.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('¡Suscripción confirmada!');">
+          <input type="email" required placeholder="Suscríbete con tu correo electrónico">
+          <button type="submit">Suscribirme</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. Todos los derechos reservados · <a href="https://kovacictalent.com/privacy-terms/#privacy">Privacidad</a> · <a href="https://kovacictalent.com/privacy-terms/#terms">Términos</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Tu privacidad es importante</strong>
+      <p id="cookie-banner-desc">Usamos cookies para mantener funciones esenciales, analizar el rendimiento y apoyar el marketing. Puedes actualizar tus preferencias cuando quieras.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Aceptar</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Preferencias de cookies</h2>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Cerrar preferencias de cookies"><span aria-hidden="true">&times;</span></button>
+      </header>
+      <p class="cookie-modal-intro">Decide qué cookies opcionales podemos usar. Las cookies esenciales permanecen activas para garantizar las funciones fundamentales del sitio.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Esenciales</span>
+            <span class="cookie-row-desc">Necesarias para funciones básicas como la navegación, la seguridad y recordar tus preferencias.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analítica</span>
+            <span class="cookie-row-desc">Nos permite entender cómo utilizan esta página los visitantes para mejorar la experiencia.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Nos ayuda a personalizar el contenido y los mensajes según tus intereses.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Guardar preferencias</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const yearTarget = document.getElementById('y');
+    if(yearTarget){
+      yearTarget.textContent = new Date().getFullYear();
+    }
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>

--- a/cv_feedback_es.html
+++ b/cv_feedback_es.html
@@ -1,0 +1,672 @@
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group"><!-- wp:html -->
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent — Reclutamiento Ejecutivo</title>
+  <meta name="description" content="Búsqueda ejecutiva boutique y selección especializada para empresas de alto crecimiento." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad:clamp(16px,3.2vw,28px);
+      --w:1180px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    body.cookie-modal-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    .muted{color:var(--muted)}
+    .container{max-width:var(--w);margin-inline:auto;padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{width:12px;height:12px;display:block}
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    .topbar{background:#111;color:#fff;font-size:.85rem}
+    .topbar .inner{display:flex;justify-content:space-between;align-items:center;height:40px}
+    .topbar .social a{opacity:.85;margin-left:14px}
+    .topbar .social a:hover{opacity:1}
+
+    .kcvf *{box-sizing:border-box}
+    .kcvf{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:#fff}
+    .kcvf a{color:var(--accent);text-decoration:none}
+    .kcvf a:hover{text-decoration:underline}
+    .kcvf-container{max-width:1100px;margin:0 auto;padding:clamp(20px,4vw,48px)}
+    .kcvf-hero{display:grid;grid-template-columns:1.1fr .9fr;gap:36px;align-items:center;background:linear-gradient(180deg,#fff0%,#f8fafc 100%);border-radius:var(--radius);box-shadow:0 12px 32px rgba(16,24,40,.1);padding:clamp(24px,3vw,40px);position:relative;overflow:hidden}
+    .kcvf-eyebrow{display:inline-flex;align-items:center;gap:8px;background:rgba(10,33,46,.08);color:#0A212E;padding:6px 12px;border-radius:999px;font-weight:600;letter-spacing:.2px;font-size:.9rem}
+    .kcvf-title{font-size:clamp(28px,4.2vw,44px);line-height:1.05;margin:.4rem 0 1rem}
+    .kcvf-title .accent{color:var(--accent)}
+    .kcvf-sub{color:#475569;font-size:clamp(15px,1.4vw,18px);max-width:52ch}
+    .kcvf-hero-cta{display:flex;gap:14px;align-items:center;margin-top:18px;flex-wrap:wrap}
+    .kcvf-badge{display:inline-flex;align-items:center;gap:8px;background:rgba(10,33,46,.08);color:#0A212E;padding:8px 12px;border-radius:12px;font-weight:600;font-size:.95rem}
+    .kcvf-hero img{width:100%;height:auto;border-radius:var(--radius);box-shadow:var(--shadow)}
+    .kcvf-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:34px}
+    .kcvf-card{background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:20px;box-shadow:0 6px 18px rgba(16,24,40,.06)}
+    .kcvf-card h3{margin:.2rem 0 .4rem;font-size:1.05rem}
+    .kcvf-card p{color:var(--muted);font-size:.98rem;line-height:1.55}
+    .kcvf-ico{width:38px;height:38px;border-radius:12px;display:inline-grid;place-items:center;background:rgba(10,33,46,.08);color:#0A212E;margin-bottom:10px}
+    .kcvf-ico svg{stroke:currentColor}
+    .kcvf-steps{margin-top:42px;display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:center}
+    .kcvf-steps ol{counter-reset:step;list-style:none;padding:0;margin:0}
+    .kcvf-steps li{counter-increment:step;background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:16px 16px 16px 58px;position:relative;margin-bottom:12px;box-shadow:0 8px 20px rgba(16,24,40,.05)}
+    .kcvf-steps li:before{content:counter(step);position:absolute;left:16px;top:50%;transform:translateY(-50%);width:32px;height:32px;border-radius:10px;background:var(--accent);color:#fff;display:grid;place-items:center;font-weight:700}
+    .kcvf-steps p{margin:.2rem 0;color:#475569}
+    .kcvf-steps .illus img{width:100%;border-radius:var(--radius);box-shadow:var(--shadow)}
+    .kcvf-formwrap{margin-top:38px;background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:22px;box-shadow:var(--shadow)}
+    .kcvf-formwrap h3{margin:0 0 8px}
+    .kcvf-formwrap p{color:var(--muted)}
+    .kcvf-toggle{margin-top:10px;padding:8px 14px;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;font-weight:600}
+    .kcvf-toggle:hover{filter:brightness(.95)}
+    .kcvf-shortcode{display:none;margin-top:14px;padding:16px;border-radius:12px;background:#f4f6f8;border:1px dashed rgba(10,33,46,.25)}
+    .kcvf-shortcode strong{color:var(--ink)}
+    .kcvf-faq{margin-top:42px;display:grid;grid-template-columns:repeat(2,1fr);gap:18px}
+    .kcvf-faq .q{background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:18px;box-shadow:0 10px 18px rgba(16,24,40,.05)}
+    .kcvf-faq h4{margin:.2rem 0 .3rem}
+
+    footer{background:#0b1220;color:#cbd5e1;padding-block:44px 28px;margin-top:clamp(40px,6vw,80px)}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800;cursor:pointer}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    footer a{color:#cbd5e1}
+
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+      .footer-inner{grid-template-columns:1fr;text-align:center}
+      .newsletter{justify-content:center}
+    }
+
+    @media (max-width:900px){
+      .topbar .inner{flex-direction:column;gap:8px;height:auto;padding-block:8px;text-align:center}
+      .kcvf-hero,.kcvf-steps{grid-template-columns:1fr}
+      .kcvf-grid{grid-template-columns:1fr;gap:14px}
+      .kcvf-faq{grid-template-columns:1fr}
+    }
+
+    @media (max-width:640px){
+      .kcvf-hero{padding:20px}
+      .kcvf-hero-cta{flex-direction:column;align-items:flex-start}
+      .newsletter{flex-direction:column}
+      .newsletter input,
+      .newsletter button{width:100%}
+    }
+  </style>
+</head>
+<body>
+
+
+  <nav class="nav" aria-label="Navegación principal">
+    <div class="container inner">
+      <a class="logo" href="https://kovacictalent.com/"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Logotipo de Kovacic Talent" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Abrir o cerrar la navegación" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menú</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="https://kovacictalent.com/#sectors">Sectores</a>
+          <a href="https://kovacictalent.com/#About">Sobre nosotros</a>
+          <a href="https://kovacictalent.com/#Values">Nuestros valores</a>
+          <a href="https://kovacictalent.com/#process">Cómo trabajamos</a>
+          <a href="https://kovacictalent.com/#processes">Procesos</a>
+          <a href="https://kovacictalent.com/#contact">Contacto</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Enviar CV</a>
+          <a class="btn btn-primary" href="https://kovacictalent.com/#contact">Solicitar una llamada</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent en LinkedIn (se abre en una pestaña nueva)">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="kcvf">
+    <div class="kcvf-container">
+      <section class="kcvf-formwrap" style="margin-top:0">
+        <h3>Registra tu CV para futuras oportunidades</h3>
+        <p>Sube tu CV para que podamos contactarte y mantenerte informado.</p>
+        <button class="kcvf-toggle" id="toggle-cv-form" aria-expanded="false">Registrar CV</button>
+        <div class="kcvf-shortcode" id="cv-form">
+          <strong>[kovacic_cv_register]</strong>
+        </div>
+      </section>
+
+      <header class="kcvf-hero">
+        <div>
+          <span class="kcvf-eyebrow">Desarrollado internamente por Kovacic Executive Talent Research</span>
+          <h1 class="kcvf-title">Potencia el impacto de tu CV <span class="accent"></span></h1>
+          <p class="kcvf-sub">
+            Nuestro sistema analiza tu CV en <strong>múltiples puntos de evaluación</strong>
+            (estructura, impacto, palabras clave, ATS y más) para darte <strong>retroalimentación personalizada</strong>
+            que te ayude a destacar en futuras oportunidades.
+          </p>
+          <div class="kcvf-hero-cta">
+            <span class="kcvf-badge">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M20 7L9 18l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              Retroalimentación clara y accionable
+            </span>
+            <span class="kcvf-badge">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 8v4l3 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/></svg>
+              En cuestión de minutos
+            </span>
+            <span class="kcvf-badge">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4 12h16M4 6h16M4 18h10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+              Compatible con ATS
+            </span>
+          </div>
+        </div>
+        <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_1035652596-scaled.jpeg"
+             alt="Reclutadores profesionales analizando un CV">
+      </header>
+
+      <section class="kcvf-grid" aria-label="Puntos de valor">
+        <article class="kcvf-card">
+          <div class="kcvf-ico">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="7" r="4" stroke="currentColor" stroke-width="2"/></svg>
+          </div>
+          <h3>Personalizado</h3>
+          <p>La retroalimentación se adapta a tu <strong>rol y sector</strong>, resaltando logros y fortalezas relevantes.</p>
+        </article>
+        <article class="kcvf-card">
+          <div class="kcvf-ico">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M3 12h18M3 6h18M3 18h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </div>
+          <h3>Compatible con ATS</h3>
+          <p>Recomendaciones para mejorar la <strong>legibilidad y las palabras clave</strong> sin perder estilo profesional.</p>
+        </article>
+        <article class="kcvf-card">
+          <div class="kcvf-ico">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </div>
+          <h3>Desarrollado internamente</h3>
+          <p>Solución creada por <strong>Kovacic Executive Talent Research</strong> para impulsar tu candidatura.</p>
+        </article>
+      </section>
+
+      <section class="kcvf-steps">
+        <div>
+          <h2>¿Cómo funciona?</h2>
+          <ol>
+            <li>
+              <strong>Sube tu CV y cuéntanos tu objetivo.</strong>
+              <p>Indica el rol/área y el sector para lograr un análisis más preciso.</p>
+            </li>
+            <li>
+              <strong>Analizamos múltiples puntos de evaluación.</strong>
+              <p>Estructura, logros cuantificados, palabras clave, legibilidad y ajuste ATS.</p>
+            </li>
+            <li>
+              <strong>Recibe retroalimentación clara y accionable.</strong>
+              <p><em>Top 5 mejoras</em>, consejos de métricas, revisión sección por sección y un <em>resumen mejorado</em>.</p>
+            </li>
+          </ol>
+        </div>
+        <div class="illus">
+          <img src="https://images.unsplash.com/photo-1551836022-d5d88e9218df?auto=format&fit=crop&w=900&q=80"
+               alt="Ejecutivo revisando un currículum en la oficina">
+        </div>
+      </section>
+
+      <section style="margin-top:36px">
+        <div class="kcvf-card" style="padding:24px">
+          <h2 style="margin:.2rem 0 10px">¿Por qué esta herramienta?</h2>
+          <p style="color:#475569; max-width:80ch">
+            En <strong>Kovacic Executive Talent Research</strong> desarrollamos esta herramienta internamente para ayudarte a
+            <strong>optimizar tu CV</strong> con recomendaciones prácticas. El sistema combina las señales que valoran los reclutadores
+            (claridad, impacto, relevancia, palabras clave y cumplimiento ATS) para ofrecer <strong>retroalimentación personalizada</strong>
+            que mejora tu presentación y posiciona mejor tu candidatura.
+          </p>
+        </div>
+      </section>
+
+      <section class="kcvf-formwrap" id="submit-cv">
+        <h3>Envía tu CV para recibir feedback</h3>
+        <p>Sube tu documento y recibe recomendaciones en pocos minutos.</p>
+        <div class="kcvf-shortcode" style="display:block">
+          <strong>[kovacic_cv_submit]</strong>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Búsqueda ejecutiva y selección de especialistas senior en Tecnología y Energía Renovable. Servicio boutique, alcance global.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('¡Suscripción confirmada!');">
+          <input type="email" required placeholder="Suscríbete con tu correo electrónico">
+          <button type="submit">Suscribirme</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. Todos los derechos reservados · <a href="https://kovacictalent.com/privacy-terms/#privacy">Privacidad</a> · <a href="https://kovacictalent.com/privacy-terms/#terms">Términos</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Tu privacidad es importante</strong>
+      <p id="cookie-banner-desc">Usamos cookies para mantener funciones esenciales, analizar el rendimiento y apoyar el marketing. Puedes actualizar tus preferencias cuando quieras.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Aceptar</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Preferencias de cookies</h2>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Cerrar preferencias de cookies"><span aria-hidden="true">&times;</span></button>
+      </header>
+      <p class="cookie-modal-intro">Decide qué cookies opcionales podemos usar. Las cookies esenciales permanecen activas para garantizar las funciones fundamentales del sitio.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Esenciales</span>
+            <span class="cookie-row-desc">Necesarias para funciones básicas como la navegación, la seguridad y recordar tus preferencias.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analítica</span>
+            <span class="cookie-row-desc">Nos permite entender cómo utilizan esta página los visitantes para mejorar la experiencia.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Nos ayuda a personalizar el contenido y los mensajes según tus intereses.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Guardar preferencias</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const yearTarget = document.getElementById('y');
+    if(yearTarget){
+      yearTarget.textContent = new Date().getFullYear();
+    }
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>
+<!-- /wp:html --></main>
+<!-- /wp:group -->

--- a/page2_es.html
+++ b/page2_es.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Kovacic Talent - Reclutamiento Ejecutivo</title>
   <meta name="description" content="Boutique executive search & specialist recruitment for high-growth companies." />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="None">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root{
@@ -628,22 +628,22 @@
         <div class="mobile-fold-content" id="process-classic">
           <div class="grid g-4 mobile-two-cols">
             <div class="card">
-              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <svg viewbox="0 0 24 24" ...></svg>
               <strong>01 • Discovery</strong>
               <p>Profundización en el perfil de éxito, encaje cultural, rasgos de liderazgo y contexto del rol.</p>
             </div>
             <div class="card">
-              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <svg viewbox="0 0 24 24" ...></svg>
               <strong>02 • Mapping</strong>
               <p>Investigación manual de mercado, headhunting directo y construcción de una longlist validada.</p>
             </div>
             <div class="card">
-              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <svg viewbox="0 0 24 24" ...></svg>
               <strong>03 • Shortlist</strong>
               <p>Entrevistas estructuradas, evaluaciones detalladas y reportes de avance semanales.</p>
             </div>
             <div class="card">
-              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <svg viewbox="0 0 24 24" ...></svg>
               <strong>04 • Close</strong>
               <p>Estrategia de oferta, alineación de expectativas y acompañamiento en el onboarding.</p>
             </div>
@@ -671,22 +671,22 @@
         <div class="process-alt mobile-fold-content" id="process-ai">
           <div class="grid g-4 mobile-two-cols">
             <div class="card">
-              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <svg viewbox="0 0 24 24" ...></svg>
               <strong>01 • Discovery</strong>
               <p>Perfil de éxito, señales culturales, cronograma y <strong>calibración del rol basada en IA</strong>.</p>
             </div>
             <div class="card">
-              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <svg viewbox="0 0 24 24" ...></svg>
               <strong>02 • Mapping</strong>
               <p><strong>Exploración del mercado impulsada por IA + validación humana</strong>, para entregar una longlist más inteligente con mayor rapidez.</p>
             </div>
             <div class="card">
-              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <svg viewbox="0 0 24 24" ...></svg>
               <strong>03 • Shortlist</strong>
               <p>Entrevistas estructuradas, scorecards predictivos y paneles en vivo con <strong>insights semanales impulsados por IA</strong>.</p>
             </div>
             <div class="card">
-              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <svg viewbox="0 0 24 24" ...></svg>
               <strong>04 • Close</strong>
               <p>Estrategia de oferta, alineación de expectativas, soporte en onboarding, <strong>más insights de retención continuos basados en datos</strong>.</p>
             </div>
@@ -747,7 +747,7 @@
       </div>
       <div>
         <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
-          <input type="email" required="None" placeholder="Subscribe with your email">
+          <input type="email" required placeholder="Subscribe with your email">
           <button type="submit">Suscribirme</button>
         </form>
       </div>
@@ -757,24 +757,24 @@
     </div>
   </footer>
 
-  <div class="cookie-banner" data-cookie-banner="None" role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
     <div class="cookie-banner-text">
       <strong id="cookie-banner-title">Tu privacidad es importante</strong>
       <p id="cookie-banner-desc">Usamos cookies para mantener la fiabilidad del sitio, entender el rendimiento y personalizar el marketing. Ajusta tus preferencias en cualquier momento.</p>
     </div>
     <div class="cookie-banner-actions">
-      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open="None">Preferencias</button>
-      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject="None">Rechazar</button>
-      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept="None">Aceptar</button>
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Aceptar</button>
     </div>
   </div>
 
-  <div class="cookie-modal" data-cookie-modal="None" hidden="None" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
-    <div class="cookie-modal-backdrop" data-cookie-close="None"></div>
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
     <div class="cookie-modal-content" role="document">
       <header class="cookie-modal-header">
         <h2 id="cookie-modal-title">Preferencias de cookies</h2>
-        <button type="button" class="cookie-close" data-cookie-close="None" aria-label="Close cookie preferences"><span aria-hidden="true">×</span></button>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Close cookie preferences"><span aria-hidden="true">×</span></button>
       </header>
       <p class="cookie-modal-intro">Controla cómo usamos las cookies opcionales. Las cookies esenciales siempre están activas para que el sitio funcione correctamente.</p>
       <div class="cookie-options">
@@ -784,7 +784,7 @@
             <span class="cookie-row-desc">Necesarias para la navegación, la seguridad y guardar tus elecciones.</span>
           </span>
           <span class="cookie-switch">
-            <input type="checkbox" data-cookie-toggle="essential" checked="None" disabled="None">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
             <span aria-hidden="true"></span>
           </span>
         </label>
@@ -794,7 +794,7 @@
             <span class="cookie-row-desc">Nos ayuda a entender el tráfico del sitio para aplicar mejoras continuas.</span>
           </span>
           <span class="cookie-switch">
-            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first="None">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
             <span aria-hidden="true"></span>
           </span>
         </label>
@@ -810,8 +810,8 @@
         </label>
       </div>
       <div class="cookie-modal-actions">
-        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close="None">Cancelar</button>
-        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save="None">Guardar preferencias</button>
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Guardar preferencias</button>
       </div>
     </div>
   </div>

--- a/page2_es.html
+++ b/page2_es.html
@@ -1,0 +1,1177 @@
+
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent - Reclutamiento Ejecutivo</title>
+  <meta name="description" content="Boutique executive search & specialist recruitment for high-growth companies." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="None">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad: clamp(16px, 3.2vw, 28px);
+      --w: 1180px;            /* content width */
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    .muted{color:var(--muted)}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .container{max-width:var(--w); margin-inline:auto; padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+    .pill{display:inline-flex;align-items:center;gap:.5rem;color:#0f172a;background:linear-gradient(90deg,#eafcf8,#fff);border:1px solid #d9f4ee;padding:.35rem .7rem;border-radius:999px;font-weight:700;font-size:.78rem}
+    .dot{width:8px;height:8px;border-radius:999px;background:#d1d5db}
+    .dot.is-active{background:var(--accent)}
+    /* Navbar */
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{
+      width:12px;
+      height:12px;
+      display:block;
+    }
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    /* HERO */
+    .hero{position:relative;overflow:hidden}
+    .hero .inner{display:grid;grid-template-columns:1.12fr .88fr;align-items:center;gap:48px;padding-block: clamp(20px,4vw,45px)}
+    .eyebrow{font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#475569}
+    h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.08;margin:.35rem 0 1rem}
+    .hero p.sub{color:var(--muted);font-size:1.08rem;max-width:58ch}
+    .cta-row{display:flex;flex-wrap:wrap;gap:12px;margin-top:22px}
+    .hero-copy{position:relative}
+    .hero-slide{display:none}
+    .hero-slide.is-active{display:block}
+    .slider-dots{display:flex;gap:10px;align-items:center;margin-top:28px}
+
+    .hero-visual{position:relative; width:min(45vw,490px); aspect-ratio:1/1; margin-left:auto}
+    .hero-visual .ring{
+      position:absolute; inset:0; border-radius:50%;
+      background: radial-gradient(closest-side,#DDE9F0 0 73%, transparent 73%),
+                  conic-gradient(from 0deg,#f1f5f9, #DDE9F0);
+      z-index:0; opacity:.9; filter:drop-shadow(0 30px 60px rgba(2,6,23,.07));
+    }
+    .hero-visual .photo{
+      position:absolute; inset:12%; border-radius:50%; overflow:hidden; box-shadow:var(--shadow); z-index:1;
+    }
+    .hero-visual .photo img{
+      position:absolute; inset:0; width:100%; height:100%; object-fit:cover; opacity:0; transition:opacity .6s ease;
+    }
+    .hero-visual .photo img.is-active{opacity:1}
+    .hero-visual .badge{
+      position:absolute; right:8%; bottom:10%; z-index:2;
+      background:#fff; border:1px solid var(--line); border-radius:12px;
+      padding:10px 14px; box-shadow:var(--shadow); display:flex; align-items:center; gap:8px;
+      font-weight:700;
+    }
+    .hero-mobile-visual{
+      display:none;
+      width:min(320px,80vw);
+      aspect-ratio:1/1;
+      border-radius:50%;
+      overflow:hidden;
+      margin:16px auto 0;
+      box-shadow:var(--shadow);
+    }
+    .hero-mobile-visual img{
+      width:100%;
+      height:100%;
+      object-fit:cover;
+    }
+    .accent{color:var(--accent)}
+
+    /* Sections */
+    section{padding-block: clamp(24px, 4.5vw, 44px)}
+    .section-title{text-align:center;margin-bottom:8px;font-size:clamp(1.2rem,2.2vw,1.8rem)}
+    .lead{color:var(--muted);text-align:center;max-width:70ch;margin:0 auto 28px}
+    .lead-lg{font-size:1.2rem}
+    .grid{display:grid;gap:22px}
+    .g-3{grid-template-columns:repeat(3,1fr)}
+    .g-4{grid-template-columns:repeat(4,1fr)}
+    .contact-grid{grid-template-columns:1.1fr .9fr;gap:24px}
+    .card{background:#fafafa;border:1px solid var(--line);border-radius:var(--radius);padding:20px}
+    .card h3{margin:8px 0 6px}
+    .icon{width:36px;height:36px;border-radius:10px;background:linear-gradient(180deg,#eafff9,#fff);border:1px solid #d9f4ee;display:grid;place-items:center}
+    #process .card svg,
+    #process-ai .card svg{width:32px;height:32px;color:var(--accent);margin-bottom:12px}
+    #process .process-alt{margin-top:clamp(32px,5vw,60px)}
+
+    .values-title{position:relative;display:inline-block;padding-bottom:8px}
+    .values-title::after{content:"";position:absolute;left:0;bottom:0;width:100%;height:4px;background-color:#0A212E}
+    .values-grid{grid-template-columns:repeat(6,1fr)}
+    .values-grid .card{grid-column:span 2}
+    .values-grid .card:nth-child(4){grid-column:2/span 2}
+    .values-grid .card:nth-child(5){grid-column:4/span 2}
+
+    .why-choose{text-align:center}
+    .why-choose ul{list-style:none;margin:12px auto 0;padding:0;display:grid;gap:10px;max-width:520px;text-align:left}
+    .why-choose li{position:relative;padding-left:32px;color:var(--ink);font-weight:500;line-height:1.6}
+    .why-choose li::before{content:"✔️";position:absolute;left:0;top:0}
+
+    .process-block{margin-top:clamp(26px,4vw,44px)}
+    .process-block:first-of-type{margin-top:clamp(18px,3.5vw,32px)}
+    .process-header{display:flex;align-items:center;justify-content:space-between;gap:18px;flex-wrap:wrap}
+    .process-header .lead{margin:0;text-align:left;flex:1 1 260px}
+    .process-header .mobile-fold-toggle{margin-top:0}
+
+    /* Fixed sector slider — 200px tall and each image spans full width */
+    .sector-slider{
+      position:relative;
+      overflow:hidden;
+      margin-top:30px;
+      border-radius:var(--radius);
+      box-shadow:var(--shadow);
+      height:200px;
+      width:100%;
+    }
+    .sector-track{
+      display:flex;
+      height:100%;
+      width:100%;
+    }
+      .sector-track img{
+        flex:0 0 100%;
+        width:100%;
+        height:100%;
+        object-fit:cover;   /* fill left→right; crop if needed */
+        object-position:center;
+      }
+
+    /* About */
+    .about-section{padding-block:clamp(36px,6vw,86px)}
+    .about-grid{
+      display:grid;
+      grid-template-columns:minmax(0,0.9fr) minmax(0,1.1fr);
+      gap:clamp(28px,6vw,60px);
+      align-items:start;
+      grid-template-areas:
+        "visual content"
+        "details details";
+    }
+    .about-visual{grid-area:visual;position:relative;width:min(420px,42vw);aspect-ratio:1/1;margin:0 auto 0 0}
+    .about-visual .ring{
+      position:absolute;
+      inset:0;
+      border-radius:50%;
+      background: radial-gradient(closest-side,#DDE9F0 0 73%, transparent 73%),
+                  conic-gradient(from 0deg,#f1f5f9, #DDE9F0);
+      z-index:0;
+      opacity:.9;
+      filter:drop-shadow(0 30px 60px rgba(2,6,23,.07));
+    }
+    .about-visual .photo{position:absolute;inset:12%;border-radius:50%;overflow:hidden;box-shadow:var(--shadow);z-index:1}
+    .about-visual .photo img{width:100%;height:100%;object-fit:cover}
+    .about-content{grid-area:content;display:grid;gap:clamp(16px,2.6vw,22px);align-content:start}
+    .about-content .section-title{text-align:left;margin-bottom:4px}
+    .about-content h3{margin:0;font-size:1.1rem;color:var(--accent)}
+    .about-details{grid-area:details;display:grid;gap:clamp(16px,2.8vw,24px);align-content:start;margin-top:0}
+    .about-content ul,
+    .about-details ul{list-style:none;margin:0;padding:0;display:grid;gap:8px;color:var(--ink)}
+    .about-content li,
+    .about-details li{line-height:1.6}
+    .about-content li strong,
+    .about-details li strong{color:var(--accent)}
+    .about-content p,
+    .about-details p{color:var(--muted)}
+    .about-lead{margin:0;color:var(--ink);font-weight:600}
+    .about-locations{margin:0;font-weight:600;color:var(--ink)}
+    .about-locations strong{color:var(--accent)}
+
+    .mobile-fold-toggle{display:none;align-items:center;justify-content:center;gap:8px;padding:.45rem .85rem;border-radius:999px;border:1px solid var(--line);background:#fff;font-weight:600;font-size:.85rem;color:var(--accent);cursor:pointer;margin-top:8px;transition:background .2s ease,border-color .2s ease,color .2s ease}
+    .mobile-fold-toggle.fold-center{justify-content:center;margin-inline:auto}
+    .mobile-fold-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .mobile-fold-toggle:focus-visible{outline:3px solid rgba(10,33,46,.3);outline-offset:3px}
+    .mobile-fold-toggle .fold-icon{width:22px;height:22px;border:1px solid currentColor;border-radius:999px;display:grid;place-items:center;font-size:.85rem;font-weight:700;line-height:1}
+    .mobile-fold-toggle .fold-icon::before{content:"+";transform:translateY(-1px)}
+    .mobile-fold-toggle.is-expanded .fold-icon::before{content:"–"}
+    .mobile-fold-toggle.is-expanded{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .mobile-fold-toggle.is-expanded .fold-icon{border-color:#fff}
+    .mobile-fold-content{margin-top:clamp(14px,2vw,20px)}
+    .about-details.mobile-fold-content{margin-top:0}
+
+      /* Testimonials */
+      .testis{background:#f6f8fb;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+    .section-beige{background:var(--beige);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+    blockquote{max-width:860px;margin:0 auto;padding:0 20px;font-size:1.1rem;line-height:1.6;text-align:center;color:#0f172a}
+    cite{display:block;margin-top:10px;color:#475569;font-style:normal;font-weight:700}
+
+    /* Footer */
+    footer{background:#0b1220;color:#cbd5e1}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+
+    /* Cookie consent */
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+    body.cookie-modal-open{overflow:hidden}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    /* Responsive */
+      @media (max-width: 980px){
+        .menu-toggle{display:inline-flex}
+        .hero .inner{grid-template-columns:1fr;text-align:center}
+        .hero .hero-copy{max-width:560px;margin:0 auto}
+        .hero p.sub{margin-inline:auto}
+        .hero-visual{margin:0 auto;overflow:hidden}
+        .hero-visual .ring{right:-40vw;top:-28vw}
+        .hero-visual .photo{margin-inline:auto}
+        .footer-inner{grid-template-columns:1fr}
+        .about-grid{
+          grid-template-columns:1fr;
+          grid-template-areas:
+            "visual"
+            "content"
+            "details";
+        }
+        .about-visual{margin:0 auto;width:min(320px,80vw)}
+        .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+        .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+        .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+        .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+        .menu a:first-child{border-top:none}
+        .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+        .nav-cta .btn{width:100%;justify-content:center}
+      }
+
+      @media (max-width: 640px){
+        .hero .hero-slide{text-align:center}
+        .hero .hero-slide > *{margin-left:auto;margin-right:auto}
+        .cta-row{flex-direction:column}
+        .cta-row .btn{width:100%;justify-content:center}
+        .slider-dots{justify-content:center}
+        .grid{grid-template-columns:1fr !important}
+        .values-grid{grid-template-columns:1fr !important}
+        .values-grid .card{grid-column:auto !important}
+        .mobile-two-cols{grid-template-columns:repeat(2,minmax(0,1fr)) !important;gap:16px}
+        .mobile-two-cols .card{padding:16px;font-size:.92rem}
+        .mobile-two-cols .card h3{font-size:1rem}
+        .mobile-two-cols .card p{font-size:.92rem;line-height:1.55}
+        .mobile-two-cols .card > strong{display:block;font-size:.9rem;margin-bottom:6px}
+        .mobile-fold-toggle{display:inline-flex}
+        .mobile-fold-toggle.fold-center{display:flex}
+        .mobile-fold-content{display:none}
+        .mobile-fold-content.is-open{display:block}
+        .process-header{gap:12px;flex-direction:column;align-items:center;text-align:center}
+        .process-header .lead{flex:unset;text-align:center}
+        .process-header .mobile-fold-toggle{width:auto;align-self:center}
+        .hero-visual{display:none}
+        .hero-visual .ring{display:none}
+        .hero-visual .photo{inset:0}
+        .hero-mobile-visual{display:block}
+        .contact-grid{grid-template-columns:1fr !important}
+        .about-content .section-title{text-align:center}
+        .about-content,
+        .about-content > *,
+        .about-content ul,
+        .about-content li,
+        .about-content p,
+        .about-content h3,
+        .about-details,
+        .about-details > *,
+        .about-details ul,
+        .about-details li,
+        .about-details p{
+          text-align:center;
+        }
+        .grid .card,
+        .grid .card > *,
+        .grid .card h3,
+        .grid .card p,
+        .grid .card strong{
+          text-align:center;
+        }
+        .why-choose,
+        .why-choose h3,
+        .why-choose ul,
+        .why-choose li{
+          text-align:center;
+        }
+        .why-choose ul{justify-items:center}
+        .contact-grid .card,
+        .contact-grid .card > *,
+        #contact .card > div{
+          text-align:center;
+        }
+        #contact .card > div{justify-content:center}
+        footer .footer-inner,
+        footer .footer-inner > *,
+        footer .mini{
+          text-align:center;
+        }
+        .newsletter{justify-content:center}
+      }
+  </style>
+</head>
+<body>
+  <!-- Navigation -->
+  <nav class="nav" aria-label="Primary navigation">
+    <div class="container inner">
+      <a class="logo" href="#"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menú</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="#sectors">Sectores</a>
+          <a href="#About">Sobre nosotros</a>
+          <a href="#Values">Nuestros valores</a>
+          <a href="#process">Cómo trabajamos</a>
+          <a href="#processes">Procesos</a>
+          <a href="#contact">Contacto</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Enviar CV</a>
+          <a class="btn btn-primary" href="#contact">Solicitar una llamada</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent on LinkedIn (opens in a new tab)">
+            <svg viewbox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- HERO -->
+  <header class="hero">
+    <div class="container inner">
+      <div class="hero-copy">
+        <div class="hero-slide is-active">
+          <h1>Conectamos talento con la energía del cambio</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_641731816-scaled.jpeg" alt="Senior professional meeting in modern office">
+          </div>
+          <span class="pill">Más de 10 años de experiencia</span>
+          <h1>Somos un <span class="accent">partner de reclutamiento</span> para empresas de alto crecimiento</h1>
+          <p class="sub">Ayudamos a organizaciones de EMEA y LATAM a identificar y atraer líderes y especialistas senior excepcionales, combinando métodos de búsqueda rigurosos con IA moderna y ética para ofrecer resultados que perduran.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="#contact">Inicia tu búsqueda</a>
+            <a class="btn btn-ghost" href="#process">Ver nuestro proceso</a>
+          </div>
+        </div>
+        <div class="hero-slide">
+          <h1>Conectamos talento con la energía del cambio</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://images.unsplash.com/photo-1551836022-4c4c79ecde51?q=80&w=1200&auto=format&fit=crop" alt="Executive handshake in office">
+          </div>
+          <span class="pill">Resultados que perduran</span>
+          <h1>85% de retención a 12 meses</h1>
+          <p class="sub">Nuestros placements prosperan a largo plazo: cuatro de cada cinco líderes continúan en el cargo tras el primer año.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="#process">Ver nuestro proceso</a>
+            <a class="btn btn-ghost" href="#contact">Inicia tu búsqueda</a>
+          </div>
+        </div>
+        <div class="hero-slide">
+          <h1>Conectamos talento con la energía del cambio</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_1035652596-scaled.jpeg?q=80&w=1200&auto=format&fit=crop" alt="Team collaboration at work">
+          </div>
+          <span class="pill">Mejora tu CV</span>
+          <h1>Feedback personal y compatible con ATS</h1>
+          <p class="sub">Sube tu CV para recibir sugerencias claras y accionables adaptadas a tu rol y sector.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="http://www.kovacictalent.com/mejoracv">Mejorar mi CV</a>
+            <a class="btn btn-ghost" href="#contact">Inicia tu búsqueda</a>
+          </div>
+        </div>
+        <div class="slider-dots" aria-label="Hero carousel navigation">
+          <span class="dot is-active" aria-hidden="true"></span>
+          <span class="dot" aria-hidden="true"></span>
+          <span class="dot" aria-hidden="true"></span>
+        </div>
+      </div>
+
+      <div class="hero-visual">
+        <div class="ring" aria-hidden="true"></div>
+        <div class="photo">
+          <img class="is-active" src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_641731816-scaled.jpeg" alt="Senior professional meeting in modern office">
+          <img src="https://images.unsplash.com/photo-1551836022-4c4c79ecde51?q=80&w=1200&auto=format&fit=crop" alt="Executive handshake in office">
+          <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_1035652596-scaled.jpeg?q=80&w=1200&auto=format&fit=crop" alt="Team collaboration at work">
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- SECTORS -->
+  <section id="sectors" class="section-beige">
+    <div class="container">
+      <h2 class="section-title"><span class="values-title">Sectores</span></h2>
+      <p class="lead">Redes profundas en tecnología y energía renovable, además de industrias adyacentes.</p>
+      <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#sectors-fold" aria-expanded="false">
+        <span class="fold-label">Leer más</span>
+        <span class="fold-icon" aria-hidden="true"></span>
+      </button>
+      <div class="mobile-fold-content" id="sectors-fold">
+        <div class="grid g-4">
+          <div class="card"><h3>Tecnología</h3><p>Ingeniería, datos, seguridad, producto y plataforma.</p></div>
+          <div class="card"><h3>Energías renovables</h3><p>Solar, eólica, BESS, red e hidrógeno.</p></div>
+          <div class="card"><h3>Servicios financieros</h3><p>PE/VC, project finance y gestión de activos.</p></div>
+          <div class="card"><h3>Industrial y operaciones</h3><p>EPC, cadena de suministro y liderazgo de operaciones.</p></div>
+        </div>
+        <div class="sector-slider">
+          <div class="sector-track">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/8478.jpg" alt="Technology sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/landscape-with-windmills-scaled.jpg" alt="Renewable energy sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/template_21-scaled.png" alt="Financial services sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/large-vecteezy_confident-factory-worker-using-digital-tablet-in-industrial_47268909_large.jpg" alt="Industrial operations sector">
+          </div>
+        </div>
+      </div>
+    </div>
+    </section>
+
+    <!-- ABOUT -->
+    <section id="About" class="about-section">
+      <div class="container">
+        <div class="about-grid">
+          <div class="about-visual">
+            <div class="ring" aria-hidden="true"></div>
+            <div class="photo">
+              <img src="https://kovacictalent.com/wp-content/uploads/2025/09/Alan2.png" alt="Senior professional meeting in modern office">
+            </div>
+          </div>
+          <div class="about-content">
+            <h2 class="section-title"><span class="values-title">Sobre nosotros</span></h2>
+            <p class="about-intro">En Kovacic somos una firma joven respaldada por un equipo con décadas de experiencia en búsqueda ejecutiva internacional. Adoptamos un modelo boutique donde la tecnología de vanguardia y la inteligencia artificial potencian nuestros procesos con mayor precisión y agilidad, siempre como complemento de lo más importante: la visión humana y la relación cercana con ejecutivos y candidatos.</p>
+            <p class="about-lead">Nuestra identidad se expresa a través de dos marcas:</p>
+            <ul>
+              <li><strong>Kovacic Talent</strong>, enfocada en posiciones técnicas, mandos medios y profesionales clave que sostienen el crecimiento.</li>
+              <li><strong>Kovacic Executive</strong>, especializada en la búsqueda de líderes senior, ejecutivos y miembros de consejo con visión global.</li>
+            </ul>
+            <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#about-fold" aria-expanded="false">
+              <span class="fold-label">Leer más</span>
+              <span class="fold-icon" aria-hidden="true"></span>
+            </button>
+          </div>
+          <div class="about-details mobile-fold-content" id="about-fold">
+
+            <p class="about-lead">Nuestras principales divisiones:</p>
+            <ul>
+              <li>🔹 <strong>Executive Search & Talent Acquisition</strong> – Reclutamiento de liderazgo estratégico y técnico.</li>
+              <li>🔹 <strong>Board & Governance</strong> – Selección de consejeros y advisory boards con experiencia internacional.</li>
+              <li>🔹 <strong>Leadership Development</strong> – Planificación de sucesión, programas de liderazgo y executive coaching.</li>
+              <li>🔹 <strong>Market Intelligence</strong> – Mapeo de talento, benchmarking y análisis de mercado.</li>
+            </ul>
+            <p>Dentro de estas divisiones operamos en sectores clave: finanzas, infraestructura, tecnología, laboratorios, hospitality, minería y energía, con un equipo de especialistas dedicado en cada área que garantiza un profundo conocimiento del sector y procesos altamente efectivos.</p>
+            <p>Nuestro valor no solo está en identificar talento, sino en ser un partner cercano que genera un impacto positivo en el mercado laboral. Trabajamos cada día en la mejora continua y en ofrecer una experiencia diferencial para candidatos y clientes, construyendo confianza, generando resultados concretos y contribuyendo al crecimiento a largo plazo.</p>
+            <p class="about-locations">Nuestras fortalezas en desarrollo de talento se apoyan en los hubs de negocio más influyentes del mundo: Nueva York, París, Madrid, Barcelona, Berlín, Roma, Ámsterdam, Oslo, Estocolmo, Ciudad de México, São Paulo, Santiago de Chile, Lima, Panamá, Shanghái y Hong Kong.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- VALUES -->
+    <section id="Values" class="container">
+    <h2 class="section-title"><span class="values-title">Nuestros valores</span></h2>
+    <p class="lead" style="text-align: center; max-width: 800px; margin: 20px auto;">
+      En <strong>Kovacic Executive Talent Research</strong>, nuestros valores guían todo lo que hacemos.
+      Definen <strong>cómo trabajamos</strong>, cómo construimos <strong>relaciones</strong> y cómo generamos
+      un <strong>impacto duradero</strong> para nuestros clientes y candidatos.
+    </p>
+    <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#values-fold" aria-expanded="false">
+      <span class="fold-label">Leer más</span>
+      <span class="fold-icon" aria-hidden="true"></span>
+    </button>
+      <div class="mobile-fold-content" id="values-fold">
+      <div class="grid values-grid">
+      <div class="card">
+        <h3>Excelencia</h3>
+        <p>Nos comprometemos con los <strong>más altos estándares</strong> en cada etapa del proceso, entregando resultados que generan <strong>un impacto real</strong> en las organizaciones.</p>
+      </div>
+      <div class="card">
+        <h3>Confianza</h3>
+        <p>Construimos <strong>relaciones sólidas y duraderas</strong> basadas en <strong>la transparencia</strong>, el respeto y la confidencialidad.</p>
+      </div>
+      <div class="card">
+        <h3>Visión humana</h3>
+        <p>Creemos en el <strong>poder transformador del liderazgo</strong>. Buscamos talento que <strong>inspira, moviliza</strong> y construye <strong>culturas sostenibles</strong>.</p>
+      </div>
+      <div class="card">
+        <h3>Perspectiva global</h3>
+        <p>Operamos <strong>sin fronteras</strong>, combinando una <strong>visión internacional</strong> con un profundo entendimiento de <strong>los contextos locales</strong>.</p>
+      </div>
+      <div class="card">
+        <h3>Adaptabilidad</h3>
+        <p>Respondemos con <strong>agilidad</strong> al cambio, reconociendo que cada organización es <strong>única</strong> y requiere <strong>soluciones a medida</strong>.</p>
+      </div>
+    </div>
+    </div>
+    </section>
+
+  <!-- PROCESS -->
+  <section id="process" class="section-beige">
+    <div class="container">
+      <h2 class="section-title"><span class="values-title">Cómo trabajamos</span></h2>
+      <div class="process-block">
+        <div class="process-header">
+          <p class="lead lead-lg"><strong>Búsqueda Ejecutiva Clásica:</strong> Etapas transparentes con resultados medibles, desde el inicio hasta la oferta firmada.</p>
+          <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#process-classic" aria-expanded="false">
+            <span class="fold-label">Leer más</span>
+            <span class="fold-icon" aria-hidden="true"></span>
+          </button>
+        </div>
+        <div class="mobile-fold-content" id="process-classic">
+          <div class="grid g-4 mobile-two-cols">
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <strong>01 • Discovery</strong>
+              <p>Profundización en el perfil de éxito, encaje cultural, rasgos de liderazgo y contexto del rol.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <strong>02 • Mapping</strong>
+              <p>Investigación manual de mercado, headhunting directo y construcción de una longlist validada.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <strong>03 • Shortlist</strong>
+              <p>Entrevistas estructuradas, evaluaciones detalladas y reportes de avance semanales.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <strong>04 • Close</strong>
+              <p>Estrategia de oferta, alineación de expectativas y acompañamiento en el onboarding.</p>
+            </div>
+          </div>
+          <div class="why-choose">
+            <h3>¿Por qué elegir la modalidad clásica?</h3>
+            <ul>
+              <li>Ideal para roles altamente confidenciales o de nicho donde la confianza y la discreción son fundamentales.</li>
+              <li>Se apoya en redes humanas profundas, relaciones y prácticas de headhunting comprobadas.</li>
+              <li>Garantiza el alineamiento cultural mediante una validación personal rigurosa en cada etapa.</li>
+              <li>Perfecto cuando la precisión, la experiencia y el criterio personalizado pesan más que la velocidad.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="process-block">
+        <div class="process-header">
+          <p class="lead lead-lg"><strong>Búsqueda potenciada con IA:</strong> Combinamos la experiencia humana con tecnología avanzada para acelerar los resultados.</p>
+          <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#process-ai" aria-expanded="false">
+            <span class="fold-label">Leer más</span>
+            <span class="fold-icon" aria-hidden="true"></span>
+          </button>
+        </div>
+        <div class="process-alt mobile-fold-content" id="process-ai">
+          <div class="grid g-4 mobile-two-cols">
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <strong>01 • Discovery</strong>
+              <p>Perfil de éxito, señales culturales, cronograma y <strong>calibración del rol basada en IA</strong>.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <strong>02 • Mapping</strong>
+              <p><strong>Exploración del mercado impulsada por IA + validación humana</strong>, para entregar una longlist más inteligente con mayor rapidez.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <strong>03 • Shortlist</strong>
+              <p>Entrevistas estructuradas, scorecards predictivos y paneles en vivo con <strong>insights semanales impulsados por IA</strong>.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...="None"></svg>
+              <strong>04 • Close</strong>
+              <p>Estrategia de oferta, alineación de expectativas, soporte en onboarding, <strong>más insights de retención continuos basados en datos</strong>.</p>
+            </div>
+          </div>
+          <div class="why-choose">
+            <h3>¿Por qué elegir la modalidad potenciada con IA?</h3>
+            <ul>
+              <li>Acelera la búsqueda con datos en tiempo real y mapeo de talento potenciado por IA.</li>
+              <li>Descubre pools de talento ocultos en geografías e industrias más amplias.</li>
+              <li>Ofrece insights medibles a través de scorecards, dashboards y analítica.</li>
+              <li>Perfecto cuando necesitas escalabilidad, transparencia y decisiones más rápidas.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- INSIGHTS -->
+  <section id="processes" class="container">
+    <h2 class="section-title"><span class="values-title">Últimos procesos</span></h2>
+    <p class="lead">Los procesos publicados más recientes</p>
+<div style="margin:1rem 0; text-align:center;">
+  <a class="btn btn-primary" href="https://kovacictalent.com/procesos-activos/">Más oportunidades</a>
+</div>
+
+    <div id="blog-posts" class="grid g-3"></div>
+  </section>
+
+  <!-- CONTACT / CTA -->
+  <section id="contact" class="container">
+    <h2 class="section-title"><span class="values-title">¿Listo para comenzar?</span></h2>
+    <p class="lead">Cuéntanos cómo se ve el éxito y diseñaremos una búsqueda a su alrededor.</p>
+    <div class="grid contact-grid">
+      <div class="card" style="display:grid;gap:10px">
+        <p class="muted">Nos encantará saber de ti; despliega abajo para enviarnos un mensaje.</p>
+        <details>
+          <summary style="cursor:pointer;font-weight:600">Abrir formulario de contacto</summary>
+          [contact-form-7 id="e7e9470" title="Sin título"]
+        </details>
+      </div>
+      <div class="card" style="display:grid;gap:10px">
+        <h3>Contacto</h3>
+        <p class="muted">📞 +34 611 897 294<br>✉️ info@kovacictalent.com<br>📍 Madrid · Barcelona · Santiago</p>
+        <div style="display:flex;gap:10px;align-items:center">
+          <span class="pill">Shortlist promedio en 12 días</span>
+          <span class="pill">Alcance global</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Búsqueda ejecutiva y selección de especialistas senior en Tecnología y Energía Renovable. Servicio boutique, alcance global.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
+          <input type="email" required="None" placeholder="Subscribe with your email">
+          <button type="submit">Suscribirme</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. Todos los derechos reservados · <a href="https://kovacictalent.com/privacy-terms/#privacy" style="color:#cbd5e1">Privacidad</a> · <a href="https://kovacictalent.com/privacy-terms/#terms" style="color:#cbd5e1">Términos</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner="None" role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Tu privacidad es importante</strong>
+      <p id="cookie-banner-desc">Usamos cookies para mantener la fiabilidad del sitio, entender el rendimiento y personalizar el marketing. Ajusta tus preferencias en cualquier momento.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open="None">Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject="None">Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept="None">Aceptar</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal="None" hidden="None" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close="None"></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Preferencias de cookies</h2>
+        <button type="button" class="cookie-close" data-cookie-close="None" aria-label="Close cookie preferences"><span aria-hidden="true">×</span></button>
+      </header>
+      <p class="cookie-modal-intro">Controla cómo usamos las cookies opcionales. Las cookies esenciales siempre están activas para que el sitio funcione correctamente.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Esenciales</span>
+            <span class="cookie-row-desc">Necesarias para la navegación, la seguridad y guardar tus elecciones.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked="None" disabled="None">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analítica</span>
+            <span class="cookie-row-desc">Nos ayuda a entender el tráfico del sitio para aplicar mejoras continuas.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first="None">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Permite personalizar el contenido y medir la efectividad de las campañas.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close="None">Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save="None">Guardar preferencias</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+
+    /* Mobile navigation */
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+
+    /* Hero carousel */
+    (function(){
+      const slides = document.querySelectorAll('.hero-visual .photo img');
+      const dots = document.querySelectorAll('.slider-dots .dot');
+      const copies = document.querySelectorAll('.hero-slide');
+      let idx = 0;
+      function show(n){
+        slides[idx].classList.remove('is-active');
+        dots[idx].classList.remove('is-active');
+        copies[idx].classList.remove('is-active');
+        idx = n;
+        slides[idx].classList.add('is-active');
+        dots[idx].classList.add('is-active');
+        copies[idx].classList.add('is-active');
+      }
+      function next(){ show((idx + 1) % slides.length); }
+      let timer = setInterval(next, 15000);
+      dots.forEach((dot,i)=>dot.addEventListener('click',()=>{show(i); clearInterval(timer); timer=setInterval(next,15000);}));      
+      // Initialize first text slide visible
+      copies[0].classList.add('is-active');
+    })();
+
+    /* Sector slider (each image = full width, 200px tall) */
+    (function(){
+      const slider = document.querySelector('.sector-slider');
+      if(!slider) return;
+      const track = slider.querySelector('.sector-track');
+      if(!track.children.length) return;
+
+      // Clone first slide for smooth loop
+      const first = track.children[0].cloneNode(true);
+      track.appendChild(first);
+
+      let sIdx = 0;
+      const duration = 600;
+      const intervalMs = 10000;
+
+      function step(){
+        sIdx++;
+        const slideWidth = slider.clientWidth;
+        track.style.transition = 'transform .6s ease';
+        track.style.transform = `translateX(-${sIdx * slideWidth}px)`;
+        if(sIdx === track.children.length - 1){
+          setTimeout(()=>{
+            track.style.transition = 'none';
+            track.style.transform = 'translateX(0)';
+            sIdx = 0;
+          }, duration);
+        }
+      }
+
+      let t = setInterval(step, intervalMs);
+      // Reset transform on resize to keep widths perfect
+      window.addEventListener('resize', ()=>{
+        track.style.transition = 'none';
+        track.style.transform = `translateX(-${sIdx * slider.clientWidth}px)`;
+      });
+    })();
+
+    /* Mobile fold controls */
+    (function(){
+      const toggles = document.querySelectorAll('[data-fold-target]');
+      if(!toggles.length) return;
+      const mobileQuery = window.matchMedia('(max-width: 640px)');
+      const defaultLabel = 'Read more';
+      const expandedLabel = 'Show less';
+
+      const sync = () => {
+        toggles.forEach(btn => {
+          const target = document.querySelector(btn.dataset.foldTarget);
+          if(!target) return;
+          const expanded = btn.getAttribute('aria-expanded') === 'true';
+          const label = btn.querySelector('.fold-label');
+          if(mobileQuery.matches){
+            target.classList.toggle('is-open', expanded);
+            btn.classList.toggle('is-expanded', expanded);
+            if(label) label.textContent = expanded ? expandedLabel : defaultLabel;
+          } else {
+            target.classList.add('is-open');
+            btn.setAttribute('aria-expanded','true');
+            btn.classList.remove('is-expanded');
+            if(label) label.textContent = defaultLabel;
+          }
+        });
+      };
+
+      toggles.forEach(btn => {
+        btn.addEventListener('click', () => {
+          if(!mobileQuery.matches) return;
+          const expanded = btn.getAttribute('aria-expanded') === 'true';
+          btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+          sync();
+        });
+      });
+
+      mobileQuery.addEventListener('change', event => {
+        if(event.matches){
+          toggles.forEach(btn => btn.setAttribute('aria-expanded','false'));
+        }
+        sync();
+      });
+
+      sync();
+    })();
+
+    /* Load latest blog posts */
+    (async function(){
+      const container = document.getElementById('blog-posts');
+      if(!container) return;
+      try{
+        const res = await fetch('https://kovacictalent.com/wp-json/wp/v2/posts?per_page=3&_embed');
+        const posts = await res.json();
+        posts.forEach(p=>{
+          const img = p._embedded && p._embedded['wp:featuredmedia'] ? p._embedded['wp:featuredmedia'][0].source_url : '';
+          const article = document.createElement('article');
+          article.className = 'card';
+          const excerpt = p.excerpt.rendered.replace(/<[^>]+>/g,'').slice(0,140);
+          article.innerHTML = `
+            ${img ? `<img src="${img}" alt="${p.title.rendered}" style="width:100%;height:160px;object-fit:cover;border-radius:var(--radius);">` : ''}
+            <h3>${p.title.rendered}</h3>
+            <p>${excerpt}</p>
+            <a href="${p.link}" style="color:var(--accent);font-weight:600;">Read more..</a>
+          `;
+          container.appendChild(article);
+        });
+      }catch(err){
+        console.error('Failed to load posts', err);
+      }
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>

--- a/page_english
+++ b/page_english
@@ -1,0 +1,1177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent - Executive Recruitment</title>
+  <meta name="description" content="Boutique executive search & specialist recruitment for high-growth companies." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad: clamp(16px, 3.2vw, 28px);
+      --w: 1180px;            /* content width */
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    .muted{color:var(--muted)}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .container{max-width:var(--w); margin-inline:auto; padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+    .pill{display:inline-flex;align-items:center;gap:.5rem;color:#0f172a;background:linear-gradient(90deg,#eafcf8,#fff);border:1px solid #d9f4ee;padding:.35rem .7rem;border-radius:999px;font-weight:700;font-size:.78rem}
+    .dot{width:8px;height:8px;border-radius:999px;background:#d1d5db}
+    .dot.is-active{background:var(--accent)}
+    /* Navbar */
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{
+      width:12px;
+      height:12px;
+      display:block;
+    }
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    /* HERO */
+    .hero{position:relative;overflow:hidden}
+    .hero .inner{display:grid;grid-template-columns:1.12fr .88fr;align-items:center;gap:48px;padding-block: clamp(20px,4vw,45px)}
+    .eyebrow{font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#475569}
+    h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.08;margin:.35rem 0 1rem}
+    .hero p.sub{color:var(--muted);font-size:1.08rem;max-width:58ch}
+    .cta-row{display:flex;flex-wrap:wrap;gap:12px;margin-top:22px}
+    .hero-copy{position:relative}
+    .hero-slide{display:none}
+    .hero-slide.is-active{display:block}
+    .slider-dots{display:flex;gap:10px;align-items:center;margin-top:28px}
+
+    .hero-visual{position:relative; width:min(45vw,490px); aspect-ratio:1/1; margin-left:auto}
+    .hero-visual .ring{
+      position:absolute; inset:0; border-radius:50%;
+      background: radial-gradient(closest-side,#DDE9F0 0 73%, transparent 73%),
+                  conic-gradient(from 0deg,#f1f5f9, #DDE9F0);
+      z-index:0; opacity:.9; filter:drop-shadow(0 30px 60px rgba(2,6,23,.07));
+    }
+    .hero-visual .photo{
+      position:absolute; inset:12%; border-radius:50%; overflow:hidden; box-shadow:var(--shadow); z-index:1;
+    }
+    .hero-visual .photo img{
+      position:absolute; inset:0; width:100%; height:100%; object-fit:cover; opacity:0; transition:opacity .6s ease;
+    }
+    .hero-visual .photo img.is-active{opacity:1}
+    .hero-visual .badge{
+      position:absolute; right:8%; bottom:10%; z-index:2;
+      background:#fff; border:1px solid var(--line); border-radius:12px;
+      padding:10px 14px; box-shadow:var(--shadow); display:flex; align-items:center; gap:8px;
+      font-weight:700;
+    }
+    .hero-mobile-visual{
+      display:none;
+      width:min(320px,80vw);
+      aspect-ratio:1/1;
+      border-radius:50%;
+      overflow:hidden;
+      margin:16px auto 0;
+      box-shadow:var(--shadow);
+    }
+    .hero-mobile-visual img{
+      width:100%;
+      height:100%;
+      object-fit:cover;
+    }
+    .accent{color:var(--accent)}
+
+    /* Sections */
+    section{padding-block: clamp(24px, 4.5vw, 44px)}
+    .section-title{text-align:center;margin-bottom:8px;font-size:clamp(1.2rem,2.2vw,1.8rem)}
+    .lead{color:var(--muted);text-align:center;max-width:70ch;margin:0 auto 28px}
+    .lead-lg{font-size:1.2rem}
+    .grid{display:grid;gap:22px}
+    .g-3{grid-template-columns:repeat(3,1fr)}
+    .g-4{grid-template-columns:repeat(4,1fr)}
+    .contact-grid{grid-template-columns:1.1fr .9fr;gap:24px}
+    .card{background:#fafafa;border:1px solid var(--line);border-radius:var(--radius);padding:20px}
+    .card h3{margin:8px 0 6px}
+    .icon{width:36px;height:36px;border-radius:10px;background:linear-gradient(180deg,#eafff9,#fff);border:1px solid #d9f4ee;display:grid;place-items:center}
+    #process .card svg,
+    #process-ai .card svg{width:32px;height:32px;color:var(--accent);margin-bottom:12px}
+    #process .process-alt{margin-top:clamp(32px,5vw,60px)}
+
+    .values-title{position:relative;display:inline-block;padding-bottom:8px}
+    .values-title::after{content:"";position:absolute;left:0;bottom:0;width:100%;height:4px;background-color:#0A212E}
+    .values-grid{grid-template-columns:repeat(6,1fr)}
+    .values-grid .card{grid-column:span 2}
+    .values-grid .card:nth-child(4){grid-column:2/span 2}
+    .values-grid .card:nth-child(5){grid-column:4/span 2}
+
+    .why-choose{text-align:center}
+    .why-choose ul{list-style:none;margin:12px auto 0;padding:0;display:grid;gap:10px;max-width:520px;text-align:left}
+    .why-choose li{position:relative;padding-left:32px;color:var(--ink);font-weight:500;line-height:1.6}
+    .why-choose li::before{content:"✔️";position:absolute;left:0;top:0}
+
+    .process-block{margin-top:clamp(26px,4vw,44px)}
+    .process-block:first-of-type{margin-top:clamp(18px,3.5vw,32px)}
+    .process-header{display:flex;align-items:center;justify-content:space-between;gap:18px;flex-wrap:wrap}
+    .process-header .lead{margin:0;text-align:left;flex:1 1 260px}
+    .process-header .mobile-fold-toggle{margin-top:0}
+
+    /* Fixed sector slider — 200px tall and each image spans full width */
+    .sector-slider{
+      position:relative;
+      overflow:hidden;
+      margin-top:30px;
+      border-radius:var(--radius);
+      box-shadow:var(--shadow);
+      height:200px;
+      width:100%;
+    }
+    .sector-track{
+      display:flex;
+      height:100%;
+      width:100%;
+    }
+      .sector-track img{
+        flex:0 0 100%;
+        width:100%;
+        height:100%;
+        object-fit:cover;   /* fill left→right; crop if needed */
+        object-position:center;
+      }
+
+    /* About */
+    .about-section{padding-block:clamp(36px,6vw,86px)}
+    .about-grid{
+      display:grid;
+      grid-template-columns:minmax(0,0.9fr) minmax(0,1.1fr);
+      gap:clamp(28px,6vw,60px);
+      align-items:start;
+      grid-template-areas:
+        "visual content"
+        "details details";
+    }
+    .about-visual{grid-area:visual;position:relative;width:min(420px,42vw);aspect-ratio:1/1;margin:0 auto 0 0}
+    .about-visual .ring{
+      position:absolute;
+      inset:0;
+      border-radius:50%;
+      background: radial-gradient(closest-side,#DDE9F0 0 73%, transparent 73%),
+                  conic-gradient(from 0deg,#f1f5f9, #DDE9F0);
+      z-index:0;
+      opacity:.9;
+      filter:drop-shadow(0 30px 60px rgba(2,6,23,.07));
+    }
+    .about-visual .photo{position:absolute;inset:12%;border-radius:50%;overflow:hidden;box-shadow:var(--shadow);z-index:1}
+    .about-visual .photo img{width:100%;height:100%;object-fit:cover}
+    .about-content{grid-area:content;display:grid;gap:clamp(16px,2.6vw,22px);align-content:start}
+    .about-content .section-title{text-align:left;margin-bottom:4px}
+    .about-content h3{margin:0;font-size:1.1rem;color:var(--accent)}
+    .about-details{grid-area:details;display:grid;gap:clamp(16px,2.8vw,24px);align-content:start;margin-top:0}
+    .about-content ul,
+    .about-details ul{list-style:none;margin:0;padding:0;display:grid;gap:8px;color:var(--ink)}
+    .about-content li,
+    .about-details li{line-height:1.6}
+    .about-content li strong,
+    .about-details li strong{color:var(--accent)}
+    .about-content p,
+    .about-details p{color:var(--muted)}
+    .about-lead{margin:0;color:var(--ink);font-weight:600}
+    .about-locations{margin:0;font-weight:600;color:var(--ink)}
+    .about-locations strong{color:var(--accent)}
+
+    .mobile-fold-toggle{display:none;align-items:center;justify-content:center;gap:8px;padding:.45rem .85rem;border-radius:999px;border:1px solid var(--line);background:#fff;font-weight:600;font-size:.85rem;color:var(--accent);cursor:pointer;margin-top:8px;transition:background .2s ease,border-color .2s ease,color .2s ease}
+    .mobile-fold-toggle.fold-center{justify-content:center;margin-inline:auto}
+    .mobile-fold-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .mobile-fold-toggle:focus-visible{outline:3px solid rgba(10,33,46,.3);outline-offset:3px}
+    .mobile-fold-toggle .fold-icon{width:22px;height:22px;border:1px solid currentColor;border-radius:999px;display:grid;place-items:center;font-size:.85rem;font-weight:700;line-height:1}
+    .mobile-fold-toggle .fold-icon::before{content:"+";transform:translateY(-1px)}
+    .mobile-fold-toggle.is-expanded .fold-icon::before{content:"–"}
+    .mobile-fold-toggle.is-expanded{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .mobile-fold-toggle.is-expanded .fold-icon{border-color:#fff}
+    .mobile-fold-content{margin-top:clamp(14px,2vw,20px)}
+    .about-details.mobile-fold-content{margin-top:0}
+
+      /* Testimonials */
+      .testis{background:#f6f8fb;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+    .section-beige{background:var(--beige);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+    blockquote{max-width:860px;margin:0 auto;padding:0 20px;font-size:1.1rem;line-height:1.6;text-align:center;color:#0f172a}
+    cite{display:block;margin-top:10px;color:#475569;font-style:normal;font-weight:700}
+
+    /* Footer */
+    footer{background:#0b1220;color:#cbd5e1}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+
+    /* Cookie consent */
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+    body.cookie-modal-open{overflow:hidden}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    /* Responsive */
+      @media (max-width: 980px){
+        .menu-toggle{display:inline-flex}
+        .hero .inner{grid-template-columns:1fr;text-align:center}
+        .hero .hero-copy{max-width:560px;margin:0 auto}
+        .hero p.sub{margin-inline:auto}
+        .hero-visual{margin:0 auto;overflow:hidden}
+        .hero-visual .ring{right:-40vw;top:-28vw}
+        .hero-visual .photo{margin-inline:auto}
+        .footer-inner{grid-template-columns:1fr}
+        .about-grid{
+          grid-template-columns:1fr;
+          grid-template-areas:
+            "visual"
+            "content"
+            "details";
+        }
+        .about-visual{margin:0 auto;width:min(320px,80vw)}
+        .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+        .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+        .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+        .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+        .menu a:first-child{border-top:none}
+        .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+        .nav-cta .btn{width:100%;justify-content:center}
+      }
+
+      @media (max-width: 640px){
+        .hero .hero-slide{text-align:center}
+        .hero .hero-slide > *{margin-left:auto;margin-right:auto}
+        .cta-row{flex-direction:column}
+        .cta-row .btn{width:100%;justify-content:center}
+        .slider-dots{justify-content:center}
+        .grid{grid-template-columns:1fr !important}
+        .values-grid{grid-template-columns:1fr !important}
+        .values-grid .card{grid-column:auto !important}
+        .mobile-two-cols{grid-template-columns:repeat(2,minmax(0,1fr)) !important;gap:16px}
+        .mobile-two-cols .card{padding:16px;font-size:.92rem}
+        .mobile-two-cols .card h3{font-size:1rem}
+        .mobile-two-cols .card p{font-size:.92rem;line-height:1.55}
+        .mobile-two-cols .card > strong{display:block;font-size:.9rem;margin-bottom:6px}
+        .mobile-fold-toggle{display:inline-flex}
+        .mobile-fold-toggle.fold-center{display:flex}
+        .mobile-fold-content{display:none}
+        .mobile-fold-content.is-open{display:block}
+        .process-header{gap:12px;flex-direction:column;align-items:center;text-align:center}
+        .process-header .lead{flex:unset;text-align:center}
+        .process-header .mobile-fold-toggle{width:auto;align-self:center}
+        .hero-visual{display:none}
+        .hero-visual .ring{display:none}
+        .hero-visual .photo{inset:0}
+        .hero-mobile-visual{display:block}
+        .contact-grid{grid-template-columns:1fr !important}
+        .about-content .section-title{text-align:center}
+        .about-content,
+        .about-content > *,
+        .about-content ul,
+        .about-content li,
+        .about-content p,
+        .about-content h3,
+        .about-details,
+        .about-details > *,
+        .about-details ul,
+        .about-details li,
+        .about-details p{
+          text-align:center;
+        }
+        .grid .card,
+        .grid .card > *,
+        .grid .card h3,
+        .grid .card p,
+        .grid .card strong{
+          text-align:center;
+        }
+        .why-choose,
+        .why-choose h3,
+        .why-choose ul,
+        .why-choose li{
+          text-align:center;
+        }
+        .why-choose ul{justify-items:center}
+        .contact-grid .card,
+        .contact-grid .card > *,
+        #contact .card > div{
+          text-align:center;
+        }
+        #contact .card > div{justify-content:center}
+        footer .footer-inner,
+        footer .footer-inner > *,
+        footer .mini{
+          text-align:center;
+        }
+        .newsletter{justify-content:center}
+      }
+  </style>
+</head>
+<body>
+  <!-- Navigation -->
+  <nav class="nav" aria-label="Primary navigation">
+    <div class="container inner">
+      <a class="logo" href="#"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menu</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="#sectors">Sectors</a>
+          <a href="#About">About us</a>
+          <a href="#Values">Our Values</a>
+          <a href="#process">How We Work</a>
+          <a href="#processes">Processes</a>
+          <a href="#contact">Contact</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Submit CV</a>
+          <a class="btn btn-primary" href="#contact">Request a Call</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent on LinkedIn (opens in a new tab)">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- HERO -->
+  <header class="hero">
+    <div class="container inner">
+      <div class="hero-copy">
+        <div class="hero-slide is-active">
+          <h1>We connect talent with the energy of change</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_641731816-scaled.jpeg" alt="Senior professional meeting in modern office">
+          </div>
+          <span class="pill">10+ Years of Experience</span>
+          <h1>We Are a <span class="accent">Recruitment Partner</span> for High-Growth Companies</h1>
+          <p class="sub">We help organizations across EMEA & LATAM identify and attract exceptional leaders and senior specialists, combining rigorous search methods with modern, ethical AI to deliver results that endure.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="#contact">Start Your Search</a>
+            <a class="btn btn-ghost" href="#process">See Our Process</a>
+          </div>
+        </div>
+        <div class="hero-slide">
+          <h1>We connect talent with the energy of change</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://images.unsplash.com/photo-1551836022-4c4c79ecde51?q=80&w=1200&auto=format&fit=crop" alt="Executive handshake in office">
+          </div>
+          <span class="pill">Results That Stick</span>
+          <h1>85% 12-Month Retention</h1>
+          <p class="sub">Our placements thrive long term, with four out of five leaders still in role after the first year.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="#process">See Our Process</a>
+            <a class="btn btn-ghost" href="#contact">Start Your Search</a>
+          </div>
+        </div>
+        <div class="hero-slide">
+          <h1>We connect talent with the energy of change</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_1035652596-scaled.jpeg?q=80&w=1200&auto=format&fit=crop" alt="Team collaboration at work">
+          </div>
+          <span class="pill">Improve Your CV</span>
+          <h1>Personal, ATS-Friendly CV Feedback</h1>
+          <p class="sub">Upload your CV to receive clear, actionable suggestions tailored to your role and sector.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="http://www.kovacictalent.com/mejoracv">Improve My CV</a>
+            <a class="btn btn-ghost" href="#contact">Start Your Search</a>
+          </div>
+        </div>
+        <div class="slider-dots" aria-label="Hero carousel navigation">
+          <span class="dot is-active" aria-hidden="true"></span>
+          <span class="dot" aria-hidden="true"></span>
+          <span class="dot" aria-hidden="true"></span>
+        </div>
+      </div>
+
+      <div class="hero-visual">
+        <div class="ring" aria-hidden="true"></div>
+        <div class="photo">
+          <img class="is-active" src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_641731816-scaled.jpeg" alt="Senior professional meeting in modern office">
+          <img src="https://images.unsplash.com/photo-1551836022-4c4c79ecde51?q=80&w=1200&auto=format&fit=crop" alt="Executive handshake in office">
+          <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_1035652596-scaled.jpeg?q=80&w=1200&auto=format&fit=crop" alt="Team collaboration at work">
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- SECTORS -->
+  <section id="sectors" class="section-beige">
+    <div class="container">
+      <h2 class="section-title"><span class="values-title">Sectors</span></h2>
+      <p class="lead">Deep networks in technology and renewable energy, plus adjacent industries.</p>
+      <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#sectors-fold" aria-expanded="false">
+        <span class="fold-label">Read more</span>
+        <span class="fold-icon" aria-hidden="true"></span>
+      </button>
+      <div class="mobile-fold-content" id="sectors-fold">
+        <div class="grid g-4">
+          <div class="card"><h3>Technology</h3><p>Engineering, Data, Security, Product & Platform.</p></div>
+          <div class="card"><h3>Renewables</h3><p>Solar, Wind, BESS, Grid & Hydrogen.</p></div>
+          <div class="card"><h3>Financial Services</h3><p>PE/VC, project finance, asset management.</p></div>
+          <div class="card"><h3>Industrial & Ops</h3><p>EPC, supply chain, operations leadership.</p></div>
+        </div>
+        <div class="sector-slider">
+          <div class="sector-track">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/8478.jpg" alt="Technology sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/landscape-with-windmills-scaled.jpg" alt="Renewable energy sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/template_21-scaled.png" alt="Financial services sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/large-vecteezy_confident-factory-worker-using-digital-tablet-in-industrial_47268909_large.jpg" alt="Industrial operations sector">
+          </div>
+        </div>
+      </div>
+    </div>
+    </section>
+
+    <!-- ABOUT -->
+    <section id="About" class="about-section">
+      <div class="container">
+        <div class="about-grid">
+          <div class="about-visual">
+            <div class="ring" aria-hidden="true"></div>
+            <div class="photo">
+              <img src="https://kovacictalent.com/wp-content/uploads/2025/09/Alan2.png" alt="Senior professional meeting in modern office">
+            </div>
+          </div>
+          <div class="about-content">
+            <h2 class="section-title"><span class="values-title">About us</span></h2>
+            <p class="about-intro">At Kovacic, we are a young firm backed by a team with decades of experience in international executive search. We embrace a boutique model where cutting-edge technology and artificial intelligence enhance our processes with greater precision and agility, always as a complement to what matters most: human insight and close relationships with executives and candidates.</p>
+            <p class="about-lead">Our identity is expressed through two brands:</p>
+            <ul>
+              <li><strong>Kovacic Talent</strong>, focused on technical positions, middle management, and key professionals who sustain growth.</li>
+              <li><strong>Kovacic Executive</strong>, specialized in the search for senior leaders, executives, and board members with a global vision.</li>
+            </ul>
+            <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#about-fold" aria-expanded="false">
+              <span class="fold-label">Read more</span>
+              <span class="fold-icon" aria-hidden="true"></span>
+            </button>
+          </div>
+          <div class="about-details mobile-fold-content" id="about-fold">
+
+            <p class="about-lead">Our main divisions:</p>
+            <ul>
+              <li>🔹 <strong>Executive Search &amp; Talent Acquisition</strong> &ndash; Strategic and technical leadership recruitment.</li>
+              <li>🔹 <strong>Board &amp; Governance</strong> &ndash; Selection of board members and advisory boards with international experience.</li>
+              <li>🔹 <strong>Leadership Development</strong> &ndash; Succession planning, leadership programs, and executive coaching.</li>
+              <li>🔹 <strong>Market Intelligence</strong> &ndash; Talent mapping, benchmarking, and market analysis.</li>
+            </ul>
+            <p>Within these divisions, we operate across core sectors: finance, infrastructure, technology, laboratories, hospitality, mining, and energy, with a dedicated team of specialists in each area, ensuring deep industry knowledge and highly effective processes.</p>
+            <p>Our value lies not only in identifying talent but in being a close partner that creates positive impact in the labor market. We work every day on continuous improvement and on delivering a distinctive experience for both candidates and clients, building trust, generating concrete results, and contributing to long-term growth.</p>
+            <p class="about-locations">Our strengths in talent development are anchored in the world&rsquo;s most influential business hubs: New York, Paris, Madrid, Barcelona, Berlin, Rome, Amsterdam, Oslo, Stockholm, Mexico City, São Paulo, Santiago de Chile, Lima, Panama, Shanghai, and Hong Kong.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- VALUES -->
+    <section id="Values" class="container">
+    <h2 class="section-title"><span class="values-title">Our Values</span></h2>
+    <p class="lead" style="text-align: center; max-width: 800px; margin: 20px auto;">
+      At <strong>Kovacic Executive Talent Research</strong>, our values guide everything we do.
+      They define <strong>how we work</strong>, how we build <strong>relationships</strong>, and how we create
+      lasting <strong>impact</strong> for our clients and candidates.
+    </p>
+    <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#values-fold" aria-expanded="false">
+      <span class="fold-label">Read more</span>
+      <span class="fold-icon" aria-hidden="true"></span>
+    </button>
+      <div class="mobile-fold-content" id="values-fold">
+      <div class="grid values-grid">
+      <div class="card">
+        <h3>Excellence</h3>
+        <p>We commit to the <strong>highest standards</strong> at every stage of the process, delivering results that generate <strong>real impact</strong> for organizations.</p>
+      </div>
+      <div class="card">
+        <h3>Trust</h3>
+        <p>We build <strong>strong and lasting relationships</strong> based on <strong>transparency</strong>, respect, and confidentiality.</p>
+      </div>
+      <div class="card">
+        <h3>Human Vision</h3>
+        <p>We believe in the <strong>transformative power of leadership</strong>. We seek talent that <strong>inspires, mobilizes</strong>, and builds <strong>sustainable cultures</strong>.</p>
+      </div>
+      <div class="card">
+        <h3>Global Perspective</h3>
+        <p>We operate <strong>without borders</strong>, combining an <strong>international outlook</strong> with deep understanding of <strong>local contexts</strong>.</p>
+      </div>
+      <div class="card">
+        <h3>Adaptability</h3>
+        <p>We respond with <strong>agility</strong> to change, recognizing that each organization is <strong>unique</strong> and requires <strong>tailored solutions</strong>.</p>
+      </div>
+    </div>
+    </div>
+    </section>
+
+  <!-- PROCESS -->
+  <section id="process" class="section-beige">
+    <div class="container">
+      <h2 class="section-title"><span class="values-title">How We Work</span></h2>
+      <div class="process-block">
+        <div class="process-header">
+          <p class="lead lead-lg"><strong>Classic Executive Search:</strong> Transparent stages with measurable outcomes, from kickoff to signed offer.</p>
+          <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#process-classic" aria-expanded="false">
+            <span class="fold-label">Read more</span>
+            <span class="fold-icon" aria-hidden="true"></span>
+          </button>
+        </div>
+        <div class="mobile-fold-content" id="process-classic">
+          <div class="grid g-4 mobile-two-cols">
+            <div class="card">
+              <svg viewBox="0 0 24 24" ...></svg>
+              <strong>01 • Discovery</strong>
+              <p>Deep dive into success profile, cultural fit, leadership traits, and role context.</p>
+            </div>
+            <div class="card">
+              <svg viewBox="0 0 24 24" ...></svg>
+              <strong>02 • Mapping</strong>
+              <p>Manual market research, direct headhunting, and building a validated longlist.</p>
+            </div>
+            <div class="card">
+              <svg viewBox="0 0 24 24" ...></svg>
+              <strong>03 • Shortlist</strong>
+              <p>Structured interviews, detailed candidate assessments, and weekly progress reports.</p>
+            </div>
+            <div class="card">
+              <svg viewBox="0 0 24 24" ...></svg>
+              <strong>04 • Close</strong>
+              <p>Offer strategy, expectation alignment, and onboarding support.</p>
+            </div>
+          </div>
+          <div class="why-choose">
+            <h3>Why choose the Classic Way?</h3>
+            <ul>
+              <li>Best for highly confidential or niche roles where trust and discretion matter most.</li>
+              <li>Relies on deep human networks, relationships, and proven headhunting practices.</li>
+              <li>Ensures cultural alignment through rigorous personal validation at every stage.</li>
+              <li>Ideal when precision, experience, and tailored judgment outweigh speed.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="process-block">
+        <div class="process-header">
+          <p class="lead lead-lg"><strong>AI-Enhanced Search:</strong> Blending human expertise with advanced technology to accelerate results.</p>
+          <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#process-ai" aria-expanded="false">
+            <span class="fold-label">Read more</span>
+            <span class="fold-icon" aria-hidden="true"></span>
+          </button>
+        </div>
+        <div class="process-alt mobile-fold-content" id="process-ai">
+          <div class="grid g-4 mobile-two-cols">
+            <div class="card">
+              <svg viewBox="0 0 24 24" ...></svg>
+              <strong>01 • Discovery</strong>
+              <p>Success profile, culture signals, timeline and <strong>AI-based role calibration</strong>.</p>
+            </div>
+            <div class="card">
+              <svg viewBox="0 0 24 24" ...></svg>
+              <strong>02 • Mapping</strong>
+              <p><strong>AI-driven market scanning + human validation</strong>, delivering a smarter longlist faster.</p>
+            </div>
+            <div class="card">
+              <svg viewBox="0 0 24 24" ...></svg>
+              <strong>03 • Shortlist</strong>
+              <p>Structured interviews, predictive scorecards, and live dashboards with <strong>weekly AI-powered insights</strong>.</p>
+            </div>
+            <div class="card">
+              <svg viewBox="0 0 24 24" ...></svg>
+              <strong>04 • Close</strong>
+              <p>Offer strategy, expectation alignment, onboarding support, <strong>plus ongoing data-driven retention insights</strong>.</p>
+            </div>
+          </div>
+          <div class="why-choose">
+            <h3>Why choose the AI-Enhanced Way?</h3>
+            <ul>
+              <li>Speeds up search with real-time data and AI-powered talent mapping.</li>
+              <li>Uncovers hidden talent pools across broader geographies and industries.</li>
+              <li>Provides measurable insights via scorecards, dashboards, and analytics.</li>
+              <li>Perfect when you need scalability, transparency, and faster decision-making.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- INSIGHTS -->
+  <section id="processes" class="container">
+    <h2 class="section-title"><span class="values-title">Latest processes</span></h2>
+    <p class="lead">The latest published processes</p>
+<div style="margin:1rem 0; text-align:center;">
+  <a class="btn btn-primary" href="https://kovacictalent.com/procesos-activos/">More opportunities</a>
+</div>
+
+    <div id="blog-posts" class="grid g-3"></div>
+  </section>
+
+  <!-- CONTACT / CTA -->
+  <section id="contact" class="container">
+    <h2 class="section-title"><span class="values-title">Ready to Start?</span></h2>
+    <p class="lead">Tell us what success looks like, we’ll build a search around it.</p>
+    <div class="grid contact-grid">
+      <div class="card" style="display:grid;gap:10px">
+        <p class="muted">We'd love to hear from you, expand below to send us a message.</p>
+        <details>
+          <summary style="cursor:pointer;font-weight:600">Open contact form</summary>
+          [contact-form-7 id="e7e9470" title="Sin título"]
+        </details>
+      </div>
+      <div class="card" style="display:grid;gap:10px">
+        <h3>Contact</h3>
+        <p class="muted">📞 +34 611 897 294<br>✉️ info@kovacictalent.com<br>📍 Madrid · Barcelona · Santiago</p>
+        <div style="display:flex;gap:10px;align-items:center">
+          <span class="pill">Avg shortlist in 12 days</span>
+          <span class="pill">Global reach</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Executive search and senior specialist recruitment across Technology and Renewable Energy. Boutique service, global reach.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
+          <input type="email" required placeholder="Subscribe with your email">
+          <button type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. All rights reserved · <a href="https://kovacictalent.com/privacy-terms/#privacy" style="color:#cbd5e1">Privacy</a> · <a href="https://kovacictalent.com/privacy-terms/#terms" style="color:#cbd5e1">Terms</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Your privacy matters</strong>
+      <p id="cookie-banner-desc">We use cookies to keep our site reliable, understand performance, and tailor marketing. Adjust your preferences at any time.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferences</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Reject</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Accept</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Cookie preferences</h2>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Close cookie preferences"><span aria-hidden="true">&times;</span></button>
+      </header>
+      <p class="cookie-modal-intro">Control how we use optional cookies. Essential cookies are always active so that the site works correctly.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Essential</span>
+            <span class="cookie-row-desc">Required for things like navigation, security, and saving your choices.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analytics</span>
+            <span class="cookie-row-desc">Helps us understand site traffic so we can make continuous improvements.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Enables personalised content and measures the effectiveness of campaigns.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancel</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Save preferences</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+
+    /* Mobile navigation */
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+
+    /* Hero carousel */
+    (function(){
+      const slides = document.querySelectorAll('.hero-visual .photo img');
+      const dots = document.querySelectorAll('.slider-dots .dot');
+      const copies = document.querySelectorAll('.hero-slide');
+      let idx = 0;
+      function show(n){
+        slides[idx].classList.remove('is-active');
+        dots[idx].classList.remove('is-active');
+        copies[idx].classList.remove('is-active');
+        idx = n;
+        slides[idx].classList.add('is-active');
+        dots[idx].classList.add('is-active');
+        copies[idx].classList.add('is-active');
+      }
+      function next(){ show((idx + 1) % slides.length); }
+      let timer = setInterval(next, 15000);
+      dots.forEach((dot,i)=>dot.addEventListener('click',()=>{show(i); clearInterval(timer); timer=setInterval(next,15000);}));      
+      // Initialize first text slide visible
+      copies[0].classList.add('is-active');
+    })();
+
+    /* Sector slider (each image = full width, 200px tall) */
+    (function(){
+      const slider = document.querySelector('.sector-slider');
+      if(!slider) return;
+      const track = slider.querySelector('.sector-track');
+      if(!track.children.length) return;
+
+      // Clone first slide for smooth loop
+      const first = track.children[0].cloneNode(true);
+      track.appendChild(first);
+
+      let sIdx = 0;
+      const duration = 600;
+      const intervalMs = 10000;
+
+      function step(){
+        sIdx++;
+        const slideWidth = slider.clientWidth;
+        track.style.transition = 'transform .6s ease';
+        track.style.transform = `translateX(-${sIdx * slideWidth}px)`;
+        if(sIdx === track.children.length - 1){
+          setTimeout(()=>{
+            track.style.transition = 'none';
+            track.style.transform = 'translateX(0)';
+            sIdx = 0;
+          }, duration);
+        }
+      }
+
+      let t = setInterval(step, intervalMs);
+      // Reset transform on resize to keep widths perfect
+      window.addEventListener('resize', ()=>{
+        track.style.transition = 'none';
+        track.style.transform = `translateX(-${sIdx * slider.clientWidth}px)`;
+      });
+    })();
+
+    /* Mobile fold controls */
+    (function(){
+      const toggles = document.querySelectorAll('[data-fold-target]');
+      if(!toggles.length) return;
+      const mobileQuery = window.matchMedia('(max-width: 640px)');
+      const defaultLabel = 'Read more';
+      const expandedLabel = 'Show less';
+
+      const sync = () => {
+        toggles.forEach(btn => {
+          const target = document.querySelector(btn.dataset.foldTarget);
+          if(!target) return;
+          const expanded = btn.getAttribute('aria-expanded') === 'true';
+          const label = btn.querySelector('.fold-label');
+          if(mobileQuery.matches){
+            target.classList.toggle('is-open', expanded);
+            btn.classList.toggle('is-expanded', expanded);
+            if(label) label.textContent = expanded ? expandedLabel : defaultLabel;
+          } else {
+            target.classList.add('is-open');
+            btn.setAttribute('aria-expanded','true');
+            btn.classList.remove('is-expanded');
+            if(label) label.textContent = defaultLabel;
+          }
+        });
+      };
+
+      toggles.forEach(btn => {
+        btn.addEventListener('click', () => {
+          if(!mobileQuery.matches) return;
+          const expanded = btn.getAttribute('aria-expanded') === 'true';
+          btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+          sync();
+        });
+      });
+
+      mobileQuery.addEventListener('change', event => {
+        if(event.matches){
+          toggles.forEach(btn => btn.setAttribute('aria-expanded','false'));
+        }
+        sync();
+      });
+
+      sync();
+    })();
+
+    /* Load latest blog posts */
+    (async function(){
+      const container = document.getElementById('blog-posts');
+      if(!container) return;
+      try{
+        const res = await fetch('https://kovacictalent.com/wp-json/wp/v2/posts?per_page=3&_embed');
+        const posts = await res.json();
+        posts.forEach(p=>{
+          const img = p._embedded && p._embedded['wp:featuredmedia'] ? p._embedded['wp:featuredmedia'][0].source_url : '';
+          const article = document.createElement('article');
+          article.className = 'card';
+          const excerpt = p.excerpt.rendered.replace(/<[^>]+>/g,'').slice(0,140);
+          article.innerHTML = `
+            ${img ? `<img src="${img}" alt="${p.title.rendered}" style="width:100%;height:160px;object-fit:cover;border-radius:var(--radius);">` : ''}
+            <h3>${p.title.rendered}</h3>
+            <p>${excerpt}</p>
+            <a href="${p.link}" style="color:var(--accent);font-weight:600;">Read more..</a>
+          `;
+          container.appendChild(article);
+        });
+      }catch(err){
+        console.error('Failed to load posts', err);
+      }
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>

--- a/terms_es.html
+++ b/terms_es.html
@@ -1,0 +1,755 @@
+
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent — Política de Privacidad y Términos</title>
+  <meta name="description" content="Centro legal de Kovacic Talent con la política de privacidad y los términos de servicio." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="None">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad:clamp(16px,3.2vw,28px);
+      --w:1180px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    a:hover{text-decoration:none;color:var(--accent)}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    ul{margin:0 0 1.3rem 1.25rem;padding:0}
+    li{margin:0 0 .55rem}
+    strong{font-weight:700}
+    .muted{color:var(--muted)}
+    .container{max-width:var(--w);margin-inline:auto;padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+    .pill{display:inline-flex;align-items:center;gap:.5rem;color:#0f172a;background:linear-gradient(90deg,#eafcf8,#fff);border:1px solid #d9f4ee;padding:.35rem .7rem;border-radius:999px;font-weight:700;font-size:.78rem;text-transform:uppercase;letter-spacing:.1em}
+
+    /* Navbar */
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{width:12px;height:12px;display:block}
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{outline:3px solid rgba(10,102,194,.35);outline-offset:2px}
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    /* HERO */
+    .hero{position:relative;overflow:hidden}
+    .hero .inner{display:grid;grid-template-columns:1.12fr .88fr;align-items:center;gap:48px;padding-block:clamp(36px,5vw,72px)}
+    .eyebrow{font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#475569}
+    h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.08;margin:.35rem 0 1rem}
+    h2{font-size:clamp(1.4rem,2.5vw,2rem);line-height:1.18;margin:0 0 1rem}
+    h3{font-size:1.15rem;margin:1.8rem 0 .7rem}
+    .hero p.sub{color:var(--muted);font-size:1.08rem;max-width:58ch}
+    .cta-row{display:flex;flex-wrap:wrap;gap:12px;margin-top:22px}
+    .hero-copy{position:relative}
+    .hero-slide{display:none}
+    .hero-slide.is-active{display:block}
+    .hero-visual{position:relative;width:min(45vw,490px);aspect-ratio:1/1;margin-left:auto}
+    .hero-visual .ring{
+      position:absolute;inset:0;border-radius:50%;
+      background:radial-gradient(closest-side,#DDE9F0 0 73%,transparent 73%),
+                 conic-gradient(from 0deg,#f1f5f9,#DDE9F0);
+      z-index:0;opacity:.9;filter:drop-shadow(0 30px 60px rgba(2,6,23,.07));
+    }
+    .hero-visual .photo{position:absolute;inset:12%;border-radius:50%;overflow:hidden;box-shadow:var(--shadow);z-index:1}
+    .hero-visual .photo img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity .6s ease}
+    .hero-visual .photo img.is-active{opacity:1}
+    .hero-visual .badge{position:absolute;right:8%;bottom:10%;z-index:2;background:#fff;border:1px solid var(--line);border-radius:12px;padding:10px 14px;box-shadow:var(--shadow);display:flex;align-items:center;gap:8px;font-weight:700;color:var(--accent)}
+    .hero-mobile-visual{display:none;width:min(320px,80vw);aspect-ratio:1/1;border-radius:50%;overflow:hidden;margin:16px auto 0;box-shadow:var(--shadow)}
+    .hero-mobile-visual img{width:100%;height:100%;object-fit:cover}
+    .accent{color:var(--accent)}
+
+    section{padding-block:clamp(40px,5vw,70px)}
+    .section-beige{background:var(--beige);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+    .section-title{text-align:center;margin-bottom:8px;font-size:clamp(1.2rem,2.2vw,1.8rem)}
+    .lead{color:var(--muted);max-width:70ch;margin:0 auto 28px;text-align:center}
+    .card{background:#fafafa;border:1px solid var(--line);border-radius:var(--radius);padding:20px}
+
+    /* Legal layout */
+    .legal-hero .hero-visual .badge{font-size:.85rem;letter-spacing:.03em;text-transform:uppercase}
+    .legal-overview .container{display:grid;gap:22px;justify-items:flex-start;padding-block:clamp(32px,4.8vw,56px)}
+    .legal-intro{background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);padding:clamp(24px,4vw,36px);box-shadow:var(--shadow);max-width:min(620px,100%)}
+    .legal-intro h2{margin:0 0 .6rem;font-size:clamp(1.5rem,2.6vw,2rem)}
+    .legal-intro p{margin:0;color:var(--muted);font-size:1.02rem}
+    .legal-quicklinks{display:flex;gap:12px;flex-wrap:wrap}
+    .legal-quicklinks .pill{font-size:.72rem;letter-spacing:.14em}
+
+    .legal-section{padding-block:clamp(44px,6vw,80px)}
+    .legal-container{max-width:860px;margin:0 auto;padding-inline:var(--pad)}
+    .legal-card{background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);padding:clamp(26px,4.2vw,44px);box-shadow:var(--shadow)}
+    .legal-card h2{margin:0 0 .6rem;font-size:clamp(1.5rem,2.6vw,2rem)}
+    .legal-card h3{margin:1.9rem 0 .7rem;font-size:1.12rem;color:var(--accent)}
+    .legal-card h3:first-of-type{margin-top:1.4rem}
+    .legal-meta{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:.95rem;margin-bottom:1.4rem}
+    .legal-card ul{list-style:disc}
+    .legal-card li{color:var(--ink);line-height:1.6}
+    .legal-card li:last-child{margin-bottom:0}
+    .legal-note{color:var(--muted);margin-top:1.6rem;font-size:.96rem}
+
+    .legal-contact .legal-container{padding-block:0}
+    .legal-contact-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:22px}
+    .legal-contact .card{background:#fff;border-radius:var(--radius-lg);padding:clamp(24px,4vw,32px);box-shadow:var(--shadow);border:1px solid var(--line)}
+    .legal-contact .card h3{margin:0 0 .6rem;font-size:1.18rem;color:var(--accent)}
+    .legal-contact .card p{margin:0 0 .8rem}
+    .legal-contact .card p:last-child{margin-bottom:0}
+
+    footer{background:#0b1220;color:#cbd5e1;padding-block:44px 28px;margin-top:60px}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    footer a{color:#cbd5e1}
+
+    /* Cookie consent */
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+    body.cookie-modal-open{overflow:hidden}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .hero .inner{grid-template-columns:1fr;text-align:center}
+      .hero .hero-copy{max-width:560px;margin:0 auto}
+      .hero p.sub{margin-inline:auto}
+      .hero-visual{margin:0 auto;overflow:hidden}
+      .hero-visual .ring{right:-40vw;top:-28vw}
+      .hero-visual .photo{margin-inline:auto}
+      .footer-inner{grid-template-columns:1fr}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+    }
+
+    @media (max-width:640px){
+      .hero .hero-slide{text-align:center}
+      .hero .hero-slide > *{margin-left:auto;margin-right:auto}
+      .cta-row{flex-direction:column}
+      .cta-row .btn{width:100%;justify-content:center}
+      .hero-visual{display:none}
+      .hero-mobile-visual{display:block}
+      .hero-mobile-visual img{object-position:center}
+      .legal-overview .container{justify-items:center;text-align:center}
+      .legal-intro{text-align:center}
+      .legal-quicklinks{justify-content:center}
+      .legal-card{padding:clamp(22px,5vw,34px);text-align:left}
+      .legal-contact-grid{grid-template-columns:1fr}
+      .legal-contact .card{text-align:left}
+      .newsletter{justify-content:center}
+    }
+  </style>
+</head>
+<body>
+  <!-- Navigation -->
+  <nav class="nav" aria-label="Primary navigation">
+    <div class="container inner">
+      <a class="logo" href="http://www.kovacictalent.com"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menú</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="http://www.kovacictalent.com/#sectors">Sectores</a>
+          <a href="http://www.kovacictalent.com/#About">Sobre nosotros</a>
+          <a href="http://www.kovacictalent.com/#Values">Nuestros valores</a>
+          <a href="http://www.kovacictalent.com/#process">Cómo trabajamos</a>
+          <a href="http://www.kovacictalent.com/#processes">Procesos</a>
+          <a href="http://www.kovacictalent.com/#contact">Contacto</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Enviar CV</a>
+          <a class="btn btn-primary" href="https://kovacictalent.com/#contact">Solicitar una llamada</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent on LinkedIn (opens in a new tab)">
+            <svg viewbox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- HERO -->
+  <header class="hero legal-hero" id="top">
+    <div class="container inner">
+      <div class="hero-copy">
+        <div class="hero-slide is-active">
+          <span class="pill">Centro legal</span>
+          <h1>Política de privacidad y términos</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://images.unsplash.com/photo-1521790797524-b2497295b8a0?q=80&w=1200&auto=format&fit=crop" alt="Professional reviewing legal documents">
+          </div>
+          <p class="sub">Nuestro compromiso con la privacidad, la transparencia y el uso responsable de este sitio web y nuestros servicios.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="#privacy">Leer política de privacidad</a>
+            <a class="btn btn-ghost" href="#terms">Revisar términos</a>
+          </div>
+        </div>
+      </div>
+      <div class="hero-visual">
+        <div class="ring" aria-hidden="true"></div>
+        <div class="photo">
+          <img class="is-active" src="https://images.unsplash.com/photo-1521790797524-b2497295b8a0?q=80&w=1200&auto=format&fit=crop" alt="Professional reviewing legal documents">
+        </div>
+        <div class="badge">Actualizado en enero de 2025</div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="legal-overview section-beige" aria-labelledby="legal-overview-title">
+      <div class="container">
+        <div class="legal-intro">
+          <h2 id="legal-overview-title">Cómo protegemos tu información</h2>
+          <p>Combinamos la búsqueda ejecutiva boutique con un profundo respeto por la privacidad de los datos. Conoce cómo recopilamos, usamos y protegemos la información, además de los términos que rigen el uso de nuestros servicios.</p>
+        </div>
+        <nav class="legal-quicklinks" aria-label="Legal quick links">
+          <a class="pill" href="#privacy">Política de privacidad</a>
+          <a class="pill" href="#terms">Términos y condiciones</a>
+          <a class="pill" href="#contact">Contacto</a>
+        </nav>
+      </div>
+    </section>
+
+    <section id="privacy" class="legal-section" aria-labelledby="privacy-title">
+      <div class="container legal-container">
+        <article class="legal-card">
+          <header>
+            <h2 id="privacy-title">Política de privacidad</h2>
+            <div class="legal-meta">Última actualización: enero de 2025</div>
+          </header>
+          <p>En <strong>Kovacic Executive Talent Research</strong> (“nosotros”, “nuestro”), nos comprometemos a proteger tu privacidad y garantizar el tratamiento lícito y transparente de los datos personales en cumplimiento del <strong>Reglamento General de Protección de Datos (UE) 2016/679 (GDPR)</strong> y la legislación nacional aplicable.</p>
+
+          <h3>1. Datos que recopilamos</h3>
+          <ul>
+            <li><strong>Datos de identificación y contacto</strong> (nombre, correo electrónico, número de teléfono, dirección).</li>
+            <li><strong>Información profesional</strong> (CV, historial profesional, competencias, formación, perfiles de LinkedIn).</li>
+            <li><strong>Datos de evaluación</strong> (notas de entrevistas, referencias, evaluaciones).</li>
+            <li><strong>Datos de clientes</strong> (detalles de la organización, personas de contacto, necesidades de reclutamiento).</li>
+            <li><strong>Datos técnicos</strong> (cookies, dirección IP, información del dispositivo/navegador).</li>
+          </ul>
+
+          <h3>2. Cómo utilizamos tus datos</h3>
+          <ul>
+            <li>Prestar servicios de búsqueda y reclutamiento ejecutivo.</li>
+            <li>Evaluar y presentar candidatos a los clientes (con consentimiento previo).</li>
+            <li>Comunicarnos sobre oportunidades, proyectos o colaboraciones.</li>
+            <li>Mantener relaciones comerciales con clientes y candidatos.</li>
+            <li>Cumplir obligaciones legales y regulatorias.</li>
+          </ul>
+
+          <h3>3. Base legal para el tratamiento</h3>
+          <ul>
+            <li><strong>Consentimiento</strong> (Art. 6.1.a GDPR): cuando compartes tu CV o información profesional.</li>
+            <li><strong>Contrato</strong> (Art. 6.1.b): para cumplir obligaciones derivadas de acuerdos de servicios.</li>
+            <li><strong>Intereses legítimos</strong> (Art. 6.1.f): operar y mejorar nuestros servicios respetando tus derechos.</li>
+            <li><strong>Obligaciones legales</strong> (Art. 6.1.c): obligaciones contables, fiscales o laborales.</li>
+          </ul>
+
+          <h3>4. Compartición de datos</h3>
+          <ul>
+            <li>Los perfiles de candidatos pueden compartirse con <strong>clientes</strong> como parte de los procesos de selección, con consentimiento previo explícito.</li>
+            <li>No <strong>vendemos</strong> ni intercambiamos datos personales.</li>
+            <li>Los proveedores de servicios (hosting, CRM) pueden tratar datos bajo contratos escritos con garantías adecuadas.</li>
+            <li>Las transferencias fuera del EEE se realizan únicamente con protecciones adecuadas (p. ej., Cláusulas Contractuales Tipo).</li>
+          </ul>
+
+          <h3>5. Conservación de datos</h3>
+          <ul>
+            <li>Datos de candidatos: se conservan hasta <strong>5 años</strong> salvo que solicites su eliminación antes.</li>
+            <li>Datos de clientes/negocio: se conservan durante la relación y según la normativa aplicable.</li>
+            <li>CV y materiales de candidatura: pueden conservarse para futuras oportunidades con tu consentimiento.</li>
+          </ul>
+
+          <h3>6. Tus derechos</h3>
+          <p>En virtud del GDPR puedes solicitar acceso, rectificación, supresión, limitación, oposición y portabilidad. También puedes retirar tu consentimiento en cualquier momento y presentar una reclamación ante tu autoridad de control.</p>
+          <p><strong>Contacto para solicitudes:</strong> <a href="mailto:info@kovacictalent.com">info@kovacictalent.com</a></p>
+
+          <h3>7. Medidas de seguridad</h3>
+          <p>Aplicamos medidas técnicas y organizativas (cifrado, controles de acceso, hosting seguro) para proteger los datos personales.</p>
+
+          <h3>8. Cookies y analítica</h3>
+          <p>Nuestro sitio utiliza cookies para mejorar tu experiencia y puede incluir herramientas de analítica (p. ej., Google Analytics). Puedes gestionarlas desde la configuración de tu navegador.</p>
+
+          <h3>9. Cambios en esta política</h3>
+          <p>Podemos actualizar esta política de privacidad periódicamente. Publicaremos los cambios junto con la nueva fecha de “Última actualización”.</p>
+        </article>
+      </div>
+    </section>
+    <section id="terms" class="legal-section section-beige" aria-labelledby="terms-title">
+      <div class="container legal-container">
+        <article class="legal-card">
+          <header>
+            <h2 id="terms-title">Términos y condiciones</h2>
+            <div class="legal-meta">Última actualización: enero de 2025</div>
+          </header>
+          <p>Bienvenido a <strong>Kovacic Executive Talent Research</strong>. Al acceder o utilizar nuestro sitio y servicios aceptas estos Términos y Condiciones.</p>
+
+          <h3>1. Alcance de los servicios</h3>
+          <p>Ofrecemos <strong>servicios de búsqueda ejecutiva, reclutamiento e inteligencia de mercado</strong> . La información del sitio es de carácter general y puede actualizarse sin previo aviso.</p>
+
+          <h3>2. Uso del sitio web</h3>
+          <ul>
+            <li>Utiliza el sitio solo con fines legítimos.</li>
+            <li>No intentes obtener acceso no autorizado a sistemas, datos o cuentas.</li>
+            <li>Podemos restringir o cancelar el acceso en caso de uso indebido.</li>
+          </ul>
+
+          <h3>3. Propiedad intelectual</h3>
+          <p>Todo el contenido del sitio (texto, gráficos, diseño, logotipos, materiales) es de nuestra propiedad o de nuestros licenciantes y no puede reproducirse sin autorización por escrito.</p>
+
+          <h3>4. Confidencialidad y datos de candidatos</h3>
+          <p>Las candidaturas (por ejemplo, CV) se tratan de forma confidencial. Los clientes se comprometen a mantener la misma confidencialidad sobre la información recibida.</p>
+
+          <h3>5. Limitación de responsabilidad</h3>
+          <p>Aunque procuramos la exactitud, no garantizamos que el contenido del sitio esté libre de errores ni sea adecuado para un fin específico. En la medida permitida por la ley, no seremos responsables de pérdidas o daños derivados del uso del sitio, los servicios o enlaces externos.</p>
+
+          <h3>6. Enlaces externos</h3>
+          <p>Los enlaces a sitios de terceros se proporcionan por conveniencia. No controlamos ni respaldamos su contenido y rechazamos responsabilidad por sus políticas y prácticas.</p>
+
+          <h3>7. Ley aplicable y jurisdicción</h3>
+          <p>Estos Términos se rigen por la legislación de la UE y las leyes de España. Cualquier disputa se somete a la jurisdicción exclusiva de los tribunales de Barcelona, España.</p>
+
+          <h3>8. Cambios en los términos</h3>
+          <p>Podemos actualizar estos Términos periódicamente. El uso continuado del sitio implica la aceptación de la versión actualizada.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="contact" class="legal-section legal-contact" aria-labelledby="contact-title">
+      <div class="container legal-container">
+        <div class="legal-contact-grid">
+          <div class="card">
+            <h3 id="contact-title">Solicitudes y consultas de datos</h3>
+            <p>Si deseas ejercer tus derechos o tienes preguntas sobre esta política, contáctanos directamente.</p>
+            <p><strong>Correo electrónico:</strong> <a href="mailto:info@kovacictalent.com">info@kovacictalent.com</a></p>
+            <p class="legal-note">Nuestro objetivo es responder a todas las consultas de privacidad en un plazo de <strong>48 horas</strong>.</p>
+          </div>
+          <div class="card">
+            <h3>Cómo gestionamos tu solicitud</h3>
+            <p>Al contactarnos, verificaremos tu identidad, registraremos la solicitud y responderemos con las acciones realizadas.</p>
+            <ul>
+              <li>Confirmación de recepción en un plazo de dos días laborables.</li>
+              <li>Respuesta o actualización sustancial dentro de un mes.</li>
+              <li>Transferencia segura de cualquier dato personal solicitado.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Búsqueda ejecutiva y selección de especialistas senior en Tecnología y Energía Renovable. Servicio boutique, alcance global.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
+          <input type="email" required="None" placeholder="Subscribe with your email">
+          <button type="submit">Suscribirme</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. Todos los derechos reservados · <a href="https://kovacictalent.com/privacy-terms/#privacy">Privacidad</a> · <a href="https://kovacictalent.com/privacy-terms/#terms">Términos</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner="None" role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Tu privacidad es importante</strong>
+      <p id="cookie-banner-desc">Usamos cookies para mantener funciones esenciales, analizar el rendimiento y apoyar el marketing. Actualiza tus preferencias cuando quieras.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open="None">Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject="None">Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept="None">Aceptar</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal="None" hidden="None" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close="None"></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Preferencias de cookies</h2>
+        <button type="button" class="cookie-close" data-cookie-close="None" aria-label="Close cookie preferences"><span aria-hidden="true">×</span></button>
+      </header>
+      <p class="cookie-modal-intro">Decide qué cookies opcionales podemos usar. Las cookies esenciales permanecen activas para las funciones fundamentales del sitio.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Esenciales</span>
+            <span class="cookie-row-desc">Necesarias para funciones básicas como la navegación, la seguridad y recordar tus preferencias.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked="None" disabled="None">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analítica</span>
+            <span class="cookie-row-desc">Nos ayuda a entender cómo se utiliza esta página para mejorar la experiencia.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first="None">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Permite personalizar el contenido y medir campañas en nuestros canales.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close="None">Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save="None">Guardar preferencias</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>

--- a/terms_es.html
+++ b/terms_es.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Kovacic Talent — Política de Privacidad y Términos</title>
   <meta name="description" content="Centro legal de Kovacic Talent con la política de privacidad y los términos de servicio." />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="None">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root{
@@ -456,7 +456,7 @@
       </div>
       <div>
         <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
-          <input type="email" required="None" placeholder="Subscribe with your email">
+          <input type="email" required placeholder="Subscribe with your email">
           <button type="submit">Suscribirme</button>
         </form>
       </div>
@@ -466,24 +466,24 @@
     </div>
   </footer>
 
-  <div class="cookie-banner" data-cookie-banner="None" role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
     <div class="cookie-banner-text">
       <strong id="cookie-banner-title">Tu privacidad es importante</strong>
       <p id="cookie-banner-desc">Usamos cookies para mantener funciones esenciales, analizar el rendimiento y apoyar el marketing. Actualiza tus preferencias cuando quieras.</p>
     </div>
     <div class="cookie-banner-actions">
-      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open="None">Preferencias</button>
-      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject="None">Rechazar</button>
-      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept="None">Aceptar</button>
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Aceptar</button>
     </div>
   </div>
 
-  <div class="cookie-modal" data-cookie-modal="None" hidden="None" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
-    <div class="cookie-modal-backdrop" data-cookie-close="None"></div>
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
     <div class="cookie-modal-content" role="document">
       <header class="cookie-modal-header">
         <h2 id="cookie-modal-title">Preferencias de cookies</h2>
-        <button type="button" class="cookie-close" data-cookie-close="None" aria-label="Close cookie preferences"><span aria-hidden="true">×</span></button>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Close cookie preferences"><span aria-hidden="true">×</span></button>
       </header>
       <p class="cookie-modal-intro">Decide qué cookies opcionales podemos usar. Las cookies esenciales permanecen activas para las funciones fundamentales del sitio.</p>
       <div class="cookie-options">
@@ -493,7 +493,7 @@
             <span class="cookie-row-desc">Necesarias para funciones básicas como la navegación, la seguridad y recordar tus preferencias.</span>
           </span>
           <span class="cookie-switch">
-            <input type="checkbox" data-cookie-toggle="essential" checked="None" disabled="None">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
             <span aria-hidden="true"></span>
           </span>
         </label>
@@ -503,7 +503,7 @@
             <span class="cookie-row-desc">Nos ayuda a entender cómo se utiliza esta página para mejorar la experiencia.</span>
           </span>
           <span class="cookie-switch">
-            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first="None">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
             <span aria-hidden="true"></span>
           </span>
         </label>
@@ -519,8 +519,8 @@
         </label>
       </div>
       <div class="cookie-modal-actions">
-        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close="None">Cancelar</button>
-        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save="None">Guardar preferencias</button>
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Guardar preferencias</button>
       </div>
     </div>
   </div>

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -1,3 +1,4 @@
+
 .kls-switcher-portal {
     display: block;
     width: 100%;
@@ -6,6 +7,10 @@
 .kls-switcher {
     display: flex;
     justify-content: flex-start;
+    margin: 0;
+}
+
+.kls-switcher--fallback {
     margin: 1.5rem 0;
 }
 
@@ -18,6 +23,30 @@
     border-radius: 999px;
     box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
     border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.kls-switcher--nav {
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.kls-switcher--nav .kls-switcher__buttons {
+    background: rgba(15, 23, 42, 0.08);
+    padding: 0.25rem;
+    box-shadow: none;
+    border: 1px solid rgba(15, 23, 42, 0.14);
+}
+
+.kls-switcher--nav .kls-switcher__button {
+    font-size: 0.85rem;
+    padding: 0.35rem 0.9rem;
+    color: #0f172a;
+}
+
+.kls-switcher--nav .kls-switcher__button:hover,
+.kls-switcher--nav .kls-switcher__button:focus-visible {
+    background: rgba(10, 33, 46, 0.12);
+    color: #0f172a;
 }
 
 .kls-switcher__panels {

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -1,0 +1,67 @@
+.kls-switcher {
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 16px;
+    padding: 1.5rem;
+    margin-block: 1.5rem;
+    background: #ffffff;
+    box-shadow: 0 8px 32px rgba(15, 23, 42, 0.06);
+}
+
+.kls-switcher__buttons {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(15, 23, 42, 0.04);
+    padding: 0.35rem;
+    border-radius: 999px;
+    margin-bottom: 1.25rem;
+}
+
+.kls-switcher__button {
+    border: none;
+    background: transparent;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    cursor: pointer;
+    color: #475569;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.kls-switcher__button:hover,
+.kls-switcher__button:focus-visible {
+    background: rgba(10, 33, 46, 0.12);
+    color: #0f172a;
+    outline: none;
+}
+
+.kls-switcher__button.is-active {
+    background: #0a212e;
+    color: #ffffff;
+    box-shadow: 0 6px 18px rgba(10, 33, 46, 0.25);
+}
+
+.kls-switcher__panels {
+    position: relative;
+}
+
+.kls-switcher__panel {
+    display: none;
+}
+
+.kls-switcher__panel.is-active {
+    display: block;
+    animation: kls-fade-in 0.25s ease;
+}
+
+@keyframes kls-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -30,6 +30,14 @@
     gap: 0.5rem;
 }
 
+.kls-switcher-nav-item {
+    list-style: none;
+}
+
+.kls-switcher-nav-item > .kls-switcher {
+    margin: 0;
+}
+
 .kls-switcher--nav .kls-switcher__buttons {
     background: rgba(15, 23, 42, 0.08);
     padding: 0.25rem;

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -1,20 +1,27 @@
+.kls-switcher-portal {
+    display: block;
+    width: 100%;
+}
+
 .kls-switcher {
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    border-radius: 16px;
-    padding: 1.5rem;
-    margin-block: 1.5rem;
-    background: #ffffff;
-    box-shadow: 0 8px 32px rgba(15, 23, 42, 0.06);
+    display: flex;
+    justify-content: flex-start;
+    margin: 1.5rem 0;
 }
 
 .kls-switcher__buttons {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    background: rgba(15, 23, 42, 0.04);
-    padding: 0.35rem;
+    background: rgba(15, 23, 42, 0.05);
+    padding: 0.4rem;
     border-radius: 999px;
-    margin-bottom: 1.25rem;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.kls-switcher__panels {
+    width: 100%;
 }
 
 .kls-switcher__button {
@@ -40,10 +47,6 @@
     background: #0a212e;
     color: #ffffff;
     box-shadow: 0 6px 18px rgba(10, 33, 46, 0.25);
-}
-
-.kls-switcher__panels {
-    position: relative;
 }
 
 .kls-switcher__panel {

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -1,59 +1,174 @@
 (function() {
-    function activate(panelGroup, lang) {
-        panelGroup.querySelectorAll('.kls-switcher__panel').forEach(function(panel) {
-            if (panel.dataset.lang === lang) {
-                panel.classList.add('is-active');
-                panel.setAttribute('aria-hidden', 'false');
-            } else {
-                panel.classList.remove('is-active');
-                panel.setAttribute('aria-hidden', 'true');
-            }
-        });
+    function createButton(label, lang, controlsId) {
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'kls-switcher__button';
+        button.dataset.lang = lang;
+        button.setAttribute('role', 'tab');
+        button.setAttribute('aria-controls', controlsId);
+        button.textContent = label;
+        return button;
     }
 
-    function updateButtons(buttonGroup, lang) {
-        buttonGroup.querySelectorAll('.kls-switcher__button').forEach(function(button) {
+    function collectSiblings(startNode) {
+        var nodes = [];
+        var node = startNode;
+        while (node) {
+            nodes.push(node);
+            node = node.nextSibling;
+        }
+        return nodes;
+    }
+
+    function moveNodesIntoFragment(nodes) {
+        var fragment = document.createDocumentFragment();
+        nodes.forEach(function(node) {
+            fragment.appendChild(node);
+        });
+        return fragment;
+    }
+
+    function activateLanguage(root, lang) {
+        root.dataset.activeLang = lang;
+        document.documentElement.setAttribute('data-kls-lang', lang);
+
+        var buttons = root.querySelectorAll('.kls-switcher__button');
+        buttons.forEach(function(button) {
             var isActive = button.dataset.lang === lang;
             button.classList.toggle('is-active', isActive);
             button.setAttribute('aria-selected', isActive ? 'true' : 'false');
             button.setAttribute('tabindex', isActive ? '0' : '-1');
         });
+
+        var panels = root.querySelectorAll('.kls-switcher__panel');
+        panels.forEach(function(panel) {
+            var isActive = panel.dataset.lang === lang;
+            panel.classList.toggle('is-active', isActive);
+            panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+        });
     }
 
-    function initSwitcher(container) {
-        var buttonGroup = container.querySelector('.kls-switcher__buttons');
-        var panelGroup = container.querySelector('.kls-switcher__panels');
-
-        if (!buttonGroup || !panelGroup) {
+    function initializePortal() {
+        var root = document.getElementById('kls-switcher-root');
+        if (!root) {
             return;
         }
 
+        if (root.dataset.initialized) {
+            return;
+        }
+
+        var template = root.querySelector('template');
+        if (!template) {
+            return;
+        }
+
+        var siblings = collectSiblings(root.nextSibling);
+        if (siblings.length === 0) {
+            var bodyChildren = collectSiblings(document.body.firstChild);
+            siblings = bodyChildren.filter(function(node) {
+                return node !== root;
+            });
+        }
+
+        var englishPanelId = 'kls-lang-en';
+        var spanishPanelId = 'kls-lang-es';
+
+        var controlsWrapper = document.createElement('div');
+        controlsWrapper.className = 'kls-switcher';
+
+        var buttonGroup = document.createElement('div');
+        buttonGroup.className = 'kls-switcher__buttons';
+        buttonGroup.setAttribute('role', 'tablist');
+        buttonGroup.setAttribute('aria-label', root.dataset.label || 'Language selector');
+        controlsWrapper.appendChild(buttonGroup);
+
+        var panelsWrapper = document.createElement('div');
+        panelsWrapper.className = 'kls-switcher__panels';
+
+        var englishPanel = document.createElement('div');
+        englishPanel.className = 'kls-switcher__panel';
+        englishPanel.dataset.lang = 'en';
+        englishPanel.id = englishPanelId;
+        englishPanel.setAttribute('role', 'tabpanel');
+        englishPanel.appendChild(moveNodesIntoFragment(siblings));
+
+        var spanishPanel = document.createElement('div');
+        spanishPanel.className = 'kls-switcher__panel';
+        spanishPanel.dataset.lang = 'es';
+        spanishPanel.id = spanishPanelId;
+        spanishPanel.setAttribute('role', 'tabpanel');
+        spanishPanel.innerHTML = template.innerHTML;
+
+        template.remove();
+
+        panelsWrapper.appendChild(englishPanel);
+        panelsWrapper.appendChild(spanishPanel);
+
+        var englishButton = createButton(root.dataset.englishLabel || 'English', 'en', englishPanelId);
+        var spanishButton = createButton(root.dataset.spanishLabel || 'Español', 'es', spanishPanelId);
+
+        buttonGroup.appendChild(englishButton);
+        buttonGroup.appendChild(spanishButton);
+
+        root.appendChild(controlsWrapper);
+        root.appendChild(panelsWrapper);
+
         buttonGroup.addEventListener('click', function(event) {
-            if (!(event.target instanceof HTMLElement)) {
-                return;
-            }
-
-            var button = event.target.closest('.kls-switcher__button');
-            if (!button) {
-                return;
-            }
-
-            var lang = button.dataset.lang;
-            if (!lang) {
+            var target = event.target instanceof HTMLElement ? event.target.closest('.kls-switcher__button') : null;
+            if (!target) {
                 return;
             }
 
             event.preventDefault();
-            updateButtons(buttonGroup, lang);
-            activate(panelGroup, lang);
+            var lang = target.dataset.lang;
+            if (!lang) {
+                return;
+            }
+
+            activateLanguage(root, lang);
         });
 
-        var defaultLang = container.dataset.default || 'en';
-        updateButtons(buttonGroup, defaultLang);
-        activate(panelGroup, defaultLang);
+        buttonGroup.addEventListener('keydown', function(event) {
+            var target = event.target instanceof HTMLElement ? event.target.closest('.kls-switcher__button') : null;
+            if (!target) {
+                return;
+            }
+
+            var key = event.key;
+            if (key !== 'ArrowRight' && key !== 'ArrowLeft') {
+                return;
+            }
+
+            event.preventDefault();
+            var buttons = Array.prototype.slice.call(buttonGroup.querySelectorAll('.kls-switcher__button'));
+            var index = buttons.indexOf(target);
+            if (index === -1) {
+                return;
+            }
+
+            var offset = key === 'ArrowRight' ? 1 : -1;
+            var nextIndex = (index + offset + buttons.length) % buttons.length;
+            var nextButton = buttons[nextIndex];
+            nextButton.focus();
+            if (nextButton.dataset.lang) {
+                activateLanguage(root, nextButton.dataset.lang);
+            }
+        });
+
+        root.dataset.initialized = '1';
+
+        var defaultLang = root.dataset.default || 'en';
+        if (defaultLang !== 'en' && defaultLang !== 'es') {
+            defaultLang = 'en';
+        }
+
+        activateLanguage(root, defaultLang);
     }
 
-    document.addEventListener('DOMContentLoaded', function() {
-        document.querySelectorAll('.kls-switcher').forEach(initSwitcher);
-    });
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializePortal);
+    } else {
+        initializePortal();
+    }
 })();

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -28,11 +28,11 @@
         return fragment;
     }
 
-    function activateLanguage(root, lang) {
+    function activateLanguage(root, buttonGroup, lang) {
         root.dataset.activeLang = lang;
         document.documentElement.setAttribute('data-kls-lang', lang);
 
-        var buttons = root.querySelectorAll('.kls-switcher__button');
+        var buttons = buttonGroup ? buttonGroup.querySelectorAll('.kls-switcher__button') : [];
         buttons.forEach(function(button) {
             var isActive = button.dataset.lang === lang;
             button.classList.toggle('is-active', isActive);
@@ -74,13 +74,12 @@
         var englishPanelId = 'kls-lang-en';
         var spanishPanelId = 'kls-lang-es';
 
-        var controlsWrapper = document.createElement('div');
-        controlsWrapper.className = 'kls-switcher';
-
         var buttonGroup = document.createElement('div');
         buttonGroup.className = 'kls-switcher__buttons';
         buttonGroup.setAttribute('role', 'tablist');
         buttonGroup.setAttribute('aria-label', root.dataset.label || 'Language selector');
+        var controlsWrapper = document.createElement('div');
+        controlsWrapper.className = 'kls-switcher';
         controlsWrapper.appendChild(buttonGroup);
 
         var panelsWrapper = document.createElement('div');
@@ -111,7 +110,20 @@
         buttonGroup.appendChild(englishButton);
         buttonGroup.appendChild(spanishButton);
 
-        root.appendChild(controlsWrapper);
+        var navCta = document.querySelector('.nav-cta');
+        if (navCta) {
+            controlsWrapper.classList.add('kls-switcher--nav');
+            var linkedIn = navCta.querySelector('.nav-linkedin');
+            if (linkedIn && linkedIn.parentNode === navCta) {
+                linkedIn.insertAdjacentElement('beforebegin', controlsWrapper);
+            } else {
+                navCta.appendChild(controlsWrapper);
+            }
+        } else {
+            controlsWrapper.classList.add('kls-switcher--fallback');
+            root.appendChild(controlsWrapper);
+        }
+
         root.appendChild(panelsWrapper);
 
         buttonGroup.addEventListener('click', function(event) {
@@ -126,7 +138,7 @@
                 return;
             }
 
-            activateLanguage(root, lang);
+            activateLanguage(root, buttonGroup, lang);
         });
 
         buttonGroup.addEventListener('keydown', function(event) {
@@ -152,7 +164,7 @@
             var nextButton = buttons[nextIndex];
             nextButton.focus();
             if (nextButton.dataset.lang) {
-                activateLanguage(root, nextButton.dataset.lang);
+                activateLanguage(root, buttonGroup, nextButton.dataset.lang);
             }
         });
 
@@ -163,7 +175,7 @@
             defaultLang = 'en';
         }
 
-        activateLanguage(root, defaultLang);
+        activateLanguage(root, buttonGroup, defaultLang);
     }
 
     if (document.readyState === 'loading') {

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -1,0 +1,59 @@
+(function() {
+    function activate(panelGroup, lang) {
+        panelGroup.querySelectorAll('.kls-switcher__panel').forEach(function(panel) {
+            if (panel.dataset.lang === lang) {
+                panel.classList.add('is-active');
+                panel.setAttribute('aria-hidden', 'false');
+            } else {
+                panel.classList.remove('is-active');
+                panel.setAttribute('aria-hidden', 'true');
+            }
+        });
+    }
+
+    function updateButtons(buttonGroup, lang) {
+        buttonGroup.querySelectorAll('.kls-switcher__button').forEach(function(button) {
+            var isActive = button.dataset.lang === lang;
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            button.setAttribute('tabindex', isActive ? '0' : '-1');
+        });
+    }
+
+    function initSwitcher(container) {
+        var buttonGroup = container.querySelector('.kls-switcher__buttons');
+        var panelGroup = container.querySelector('.kls-switcher__panels');
+
+        if (!buttonGroup || !panelGroup) {
+            return;
+        }
+
+        buttonGroup.addEventListener('click', function(event) {
+            if (!(event.target instanceof HTMLElement)) {
+                return;
+            }
+
+            var button = event.target.closest('.kls-switcher__button');
+            if (!button) {
+                return;
+            }
+
+            var lang = button.dataset.lang;
+            if (!lang) {
+                return;
+            }
+
+            event.preventDefault();
+            updateButtons(buttonGroup, lang);
+            activate(panelGroup, lang);
+        });
+
+        var defaultLang = container.dataset.default || 'en';
+        updateButtons(buttonGroup, defaultLang);
+        activate(panelGroup, defaultLang);
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('.kls-switcher').forEach(initSwitcher);
+    });
+})();

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Plugin Name: Kovacic Language Switcher
+ * Description: Adds a lightweight language switcher to individual pages and lets editors provide a translated HTML version of the content.
+ * Version: 1.0.0
+ * Author: Kovacic Talent
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Kovacic_Language_Switcher {
+    private const META_KEY = '_kls_translations';
+
+    public function __construct() {
+        add_action('init', [$this, 'register_assets']);
+        add_action('add_meta_boxes', [$this, 'register_meta_box']);
+        add_action('save_post_page', [$this, 'save_meta_box']);
+        add_filter('the_content', [$this, 'inject_language_switcher'], 20);
+    }
+
+    public function register_assets(): void {
+        $version = '1.0.0';
+        $base_url = plugin_dir_url(__FILE__);
+
+        wp_register_style(
+            'kls-switcher',
+            $base_url . 'assets/css/translation-switcher.css',
+            [],
+            $version
+        );
+
+        wp_register_script(
+            'kls-switcher',
+            $base_url . 'assets/js/translation-switcher.js',
+            [],
+            $version,
+            true
+        );
+    }
+
+    public function register_meta_box(): void {
+        add_meta_box(
+            'kls_translation_box',
+            __('Language switcher – Spanish translation', 'kovacic-language-switcher'),
+            [$this, 'render_meta_box'],
+            'page',
+            'normal',
+            'default'
+        );
+    }
+
+    public function render_meta_box(\WP_Post $post): void {
+        $saved = get_post_meta($post->ID, self::META_KEY, true);
+        $defaults = [
+            'enabled' => !empty($saved['spanish_content']) || !empty($saved['enabled']),
+            'default_language' => $saved['default_language'] ?? 'en',
+            'english_label' => $saved['english_label'] ?? __('English', 'kovacic-language-switcher'),
+            'spanish_label' => $saved['spanish_label'] ?? __('Español', 'kovacic-language-switcher'),
+            'spanish_content' => $saved['spanish_content'] ?? '',
+        ];
+
+        wp_nonce_field('kls_translation_box', 'kls_translation_nonce');
+        ?>
+        <p><?php esc_html_e('Provide a Spanish HTML version of this page. The original page content is treated as English.', 'kovacic-language-switcher'); ?></p>
+        <p>
+            <label for="kls_switcher_enabled">
+                <input type="checkbox" id="kls_switcher_enabled" name="kls_switcher[enabled]" value="1" <?php checked($defaults['enabled']); ?> />
+                <?php esc_html_e('Enable the language switcher on this page', 'kovacic-language-switcher'); ?>
+            </label>
+        </p>
+        <p>
+            <label for="kls_default_language" class="screen-reader-text"><?php esc_html_e('Default language', 'kovacic-language-switcher'); ?></label>
+            <strong><?php esc_html_e('Default language shown to visitors', 'kovacic-language-switcher'); ?></strong>
+            <select name="kls_switcher[default_language]" id="kls_default_language">
+                <option value="en" <?php selected($defaults['default_language'], 'en'); ?>><?php echo esc_html($defaults['english_label']); ?></option>
+                <option value="es" <?php selected($defaults['default_language'], 'es'); ?>><?php echo esc_html($defaults['spanish_label']); ?></option>
+            </select>
+        </p>
+        <p>
+            <label for="kls_english_label"><?php esc_html_e('English label', 'kovacic-language-switcher'); ?></label><br />
+            <input type="text" id="kls_english_label" name="kls_switcher[english_label]" value="<?php echo esc_attr($defaults['english_label']); ?>" class="widefat" />
+        </p>
+        <p>
+            <label for="kls_spanish_label"><?php esc_html_e('Spanish label', 'kovacic-language-switcher'); ?></label><br />
+            <input type="text" id="kls_spanish_label" name="kls_switcher[spanish_label]" value="<?php echo esc_attr($defaults['spanish_label']); ?>" class="widefat" />
+        </p>
+        <p>
+            <label for="kls_spanish_content"><strong><?php esc_html_e('Spanish translation (HTML allowed)', 'kovacic-language-switcher'); ?></strong></label>
+            <textarea id="kls_spanish_content" name="kls_switcher[spanish_content]" rows="12" class="widefat code"><?php echo esc_textarea($defaults['spanish_content']); ?></textarea>
+        </p>
+        <p class="description">
+            <?php esc_html_e('Paste the Spanish HTML markup here. Scripts and inline styles are kept intact for administrators.', 'kovacic-language-switcher'); ?>
+        </p>
+        <?php
+    }
+
+    public function save_meta_box(int $post_id): void {
+        if (!isset($_POST['kls_translation_nonce']) || !wp_verify_nonce($_POST['kls_translation_nonce'], 'kls_translation_box')) {
+            return;
+        }
+
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+
+        if (!current_user_can('edit_page', $post_id)) {
+            return;
+        }
+
+        $raw = $_POST['kls_switcher'] ?? null;
+        if (!$raw) {
+            delete_post_meta($post_id, self::META_KEY);
+            return;
+        }
+
+        $enabled = !empty($raw['enabled']);
+        $data = [
+            'enabled' => $enabled,
+            'default_language' => in_array($raw['default_language'] ?? 'en', ['en', 'es'], true) ? $raw['default_language'] : 'en',
+            'english_label' => sanitize_text_field($raw['english_label'] ?? __('English', 'kovacic-language-switcher')),
+            'spanish_label' => sanitize_text_field($raw['spanish_label'] ?? __('Español', 'kovacic-language-switcher')),
+            'spanish_content' => $this->prepare_spanish_content($raw['spanish_content'] ?? ''),
+        ];
+
+        if (!$enabled) {
+            $data['spanish_content'] = '';
+        }
+
+        if (!$data['enabled'] || empty($data['spanish_content'])) {
+            delete_post_meta($post_id, self::META_KEY);
+            return;
+        }
+
+        update_post_meta($post_id, self::META_KEY, $data);
+    }
+
+    private function prepare_spanish_content(string $content): string {
+        $content = wp_unslash($content);
+
+        if (current_user_can('unfiltered_html')) {
+            return $content;
+        }
+
+        return wp_kses_post($content);
+    }
+
+    public function inject_language_switcher(string $content): string {
+        if (!is_singular('page') || !in_the_loop() || !is_main_query()) {
+            return $content;
+        }
+
+        $post_id = get_the_ID();
+        $settings = get_post_meta($post_id, self::META_KEY, true);
+
+        if (empty($settings) || empty($settings['spanish_content'])) {
+            return $content;
+        }
+
+        wp_enqueue_style('kls-switcher');
+        wp_enqueue_script('kls-switcher');
+
+        $english_label = $settings['english_label'] ?? __('English', 'kovacic-language-switcher');
+        $spanish_label = $settings['spanish_label'] ?? __('Español', 'kovacic-language-switcher');
+        $default = $settings['default_language'] ?? 'en';
+        $default = in_array($default, ['en', 'es'], true) ? $default : 'en';
+
+        $english_active = $default === 'en' ? ' is-active' : '';
+        $spanish_active = $default === 'es' ? ' is-active' : '';
+
+        ob_start();
+        ?>
+        <div class="kls-switcher" data-default="<?php echo esc_attr($default); ?>">
+            <div class="kls-switcher__buttons" role="tablist" aria-label="<?php echo esc_attr__('Language selector', 'kovacic-language-switcher'); ?>">
+                <button type="button" class="kls-switcher__button<?php echo esc_attr($english_active); ?>" data-lang="en" role="tab" aria-selected="<?php echo $default === 'en' ? 'true' : 'false'; ?>" aria-controls="kls-lang-en">
+                    <?php echo esc_html($english_label); ?>
+                </button>
+                <button type="button" class="kls-switcher__button<?php echo esc_attr($spanish_active); ?>" data-lang="es" role="tab" aria-selected="<?php echo $default === 'es' ? 'true' : 'false'; ?>" aria-controls="kls-lang-es">
+                    <?php echo esc_html($spanish_label); ?>
+                </button>
+            </div>
+            <div class="kls-switcher__panels">
+                <div id="kls-lang-en" class="kls-switcher__panel<?php echo esc_attr($english_active); ?>" role="tabpanel" data-lang="en">
+                    <?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </div>
+                <div id="kls-lang-es" class="kls-switcher__panel<?php echo esc_attr($spanish_active); ?>" role="tabpanel" data-lang="es">
+                    <?php echo $settings['spanish_content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </div>
+            </div>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+}
+
+new Kovacic_Language_Switcher();


### PR DESCRIPTION
## Summary
- add a reusable Kovacic Language Switcher plugin for WordPress pages
- include an editor meta box to store Spanish HTML translations per page
- render a front-end toggle with accessible markup, styles, and scripts for switching between English and Spanish content

## Testing
- php -l wp-language-switcher/language-switcher.php

------
https://chatgpt.com/codex/tasks/task_e_68ccbf7ca568832abc400070646df70e