### PR TITLE
Add string-based translation workflow to language switcher

### DIFF
--- a/article_page_es.html
+++ b/article_page_es.html
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent — Artículo</title>
+  <meta name="description" content="Perspectivas del equipo de reclutamiento ejecutivo de Kovacic Talent." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad:clamp(16px,3.2vw,28px);
+      --w:1180px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    body.cookie-modal-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    .muted{color:var(--muted)}
+    .container{max-width:var(--w);margin-inline:auto;padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{width:12px;height:12px;display:block}
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    main.article-section{padding-block:clamp(40px,8vw,80px);background:linear-gradient(180deg,#f8fafc,#fff 60%)}
+    .article-frame{background:#fff;border:1px solid var(--line);border-radius:24px;box-shadow:var(--shadow);padding:clamp(24px,5vw,56px);max-width:860px;margin-inline:auto}
+    .article-frame .wp-block-post-title{font-size:clamp(2rem,4.5vw,3.4rem);line-height:1.1;margin:0 0 clamp(12px,2vw,24px)}
+    .article-frame .wp-block-post-title a{color:inherit;text-decoration:none}
+    .article-frame .wp-block-post-featured-image{margin-bottom:clamp(20px,3vw,40px);border-radius:20px;overflow:hidden}
+    .article-frame .wp-block-post-featured-image img{width:100%;height:auto;display:block}
+    .article-frame .wp-block-post-content{font-size:1.05rem;color:#1f2937;margin-top:clamp(20px,3vw,32px)}
+    .article-frame .wp-block-post-content > * + *{margin-top:1.35em}
+    .article-frame .wp-block-post-content h2{font-size:1.75rem;margin-top:2.2em}
+    .article-frame .wp-block-post-content h3{font-size:1.4rem;margin-top:2em}
+    .article-frame .wp-block-post-content h4{font-size:1.2rem;margin-top:1.8em}
+    .article-frame .wp-block-post-content img{border-radius:18px}
+    .article-frame .wp-block-post-content blockquote{margin:1.8em 0;padding:1.2em 1.4em;border-left:4px solid var(--accent);background:#f8fafc;border-radius:18px;color:#0f172a;font-style:italic}
+    .article-frame .wp-block-post-content ul,
+    .article-frame .wp-block-post-content ol{padding-left:1.4em}
+    .article-frame .wp-block-post-content li + li{margin-top:.6em}
+    .article-frame .wp-block-post-content a{color:var(--accent);text-decoration:underline;text-decoration-color:rgba(10,33,46,.3);text-decoration-thickness:2px}
+    .article-frame .wp-block-post-content table{width:100%;border-collapse:collapse}
+    .article-frame .wp-block-post-content table th,
+    .article-frame .wp-block-post-content table td{border:1px solid var(--line);padding:.75em;text-align:left}
+    .article-frame .wp-block-post-content figure{margin:1.8em 0;text-align:center}
+    .article-frame .wp-block-post-content figure img{margin-inline:auto}
+    .article-frame .wp-block-post-content figure figcaption{margin-top:.75em;font-size:.95rem;color:var(--muted)}
+    .article-frame .wp-block-post-content .aligncenter{margin:1.5em auto;display:block}
+    .article-frame .wp-block-post-content .alignleft{float:left;margin:0 1.4em 1em 0;max-width:50%}
+    .article-frame .wp-block-post-content .alignright{float:right;margin:0 0 1em 1.4em;max-width:50%}
+    .article-frame .wp-block-post-content iframe{width:100%;min-height:320px;border:none;border-radius:18px}
+    .article-cta{margin-top:clamp(28px,4.5vw,40px);display:flex;justify-content:center}
+
+    footer{background:#0b1220;color:#cbd5e1;padding-block:44px 28px;margin-top:clamp(40px,6vw,80px)}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800;cursor:pointer}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    footer a{color:#cbd5e1}
+
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+      .footer-inner{grid-template-columns:1fr;text-align:center}
+      .newsletter{justify-content:center}
+    }
+
+    @media (max-width:640px){
+      main.article-section{padding-block:clamp(28px,12vw,60px)}
+      .article-frame .wp-block-post-title{font-size:clamp(1.8rem,7vw,2.6rem)}
+      .article-frame .wp-block-post-featured-image{margin-bottom:20px}
+      .newsletter{flex-direction:column}
+      .newsletter input,
+      .newsletter button{width:100%}
+      .article-frame .wp-block-post-content .alignleft,
+      .article-frame .wp-block-post-content .alignright{float:none;margin:1.5em auto;max-width:100%}
+      .article-frame .wp-block-post-content iframe{min-height:240px}
+    }
+  </style>
+</head>
+<body>
+  <nav class="nav" aria-label="Navegación principal">
+    <div class="container inner">
+      <a class="logo" href="https://kovacictalent.com/"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Logotipo de Kovacic Talent" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Abrir o cerrar la navegación" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menú</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="https://kovacictalent.com/#sectors">Sectores</a>
+          <a href="https://kovacictalent.com/#About">Sobre nosotros</a>
+          <a href="https://kovacictalent.com/#Values">Nuestros valores</a>
+          <a href="https://kovacictalent.com/#process">Cómo trabajamos</a>
+          <a href="https://kovacictalent.com/#processes">Procesos</a>
+          <a href="https://kovacictalent.com/#contact">Contacto</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Enviar CV</a>
+          <a class="btn btn-primary" href="https://kovacictalent.com/#contact">Solicitar una llamada</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent en LinkedIn (se abre en una pestaña nueva)">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="article-section">
+    <div class="container">
+      <div class="article-frame">
+        <!-- wp:post-title /-->
+        <!-- wp:post-featured-image /-->
+        <!-- wp:post-content /-->
+        <div class="article-cta">
+          <a class="btn btn-primary" href="https://kovacictalent.com/contacta-con-nosotros">Enviar CV</a>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Búsqueda ejecutiva y selección de especialistas senior en Tecnología y Energía Renovable. Servicio boutique, alcance global.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('¡Suscripción confirmada!');">
+          <input type="email" required placeholder="Suscríbete con tu correo electrónico">
+          <button type="submit">Suscribirme</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. Todos los derechos reservados · <a href="https://kovacictalent.com/privacy-terms/#privacy">Privacidad</a> · <a href="https://kovacictalent.com/privacy-terms/#terms">Términos</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Tu privacidad es importante</strong>
+      <p id="cookie-banner-desc">Usamos cookies para mantener funciones esenciales, analizar el rendimiento y apoyar el marketing. Puedes actualizar tus preferencias cuando quieras.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Aceptar</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Preferencias de cookies</h2>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Cerrar preferencias de cookies"><span aria-hidden="true">&times;</span></button>
+      </header>
+      <p class="cookie-modal-intro">Decide qué cookies opcionales podemos usar. Las cookies esenciales permanecen activas para garantizar las funciones fundamentales del sitio.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Esenciales</span>
+            <span class="cookie-row-desc">Necesarias para funciones básicas como la navegación, la seguridad y recordar tus preferencias.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analítica</span>
+            <span class="cookie-row-desc">Nos permite entender cómo utilizan esta página los visitantes para mejorar la experiencia.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Nos ayuda a personalizar el contenido y los mensajes según tus intereses.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Guardar preferencias</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const yearTarget = document.getElementById('y');
+    if(yearTarget){
+      yearTarget.textContent = new Date().getFullYear();
+    }
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>

--- a/cv_feedback_es.html
+++ b/cv_feedback_es.html
@@ -1,0 +1,672 @@
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group"><!-- wp:html -->
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent — Reclutamiento Ejecutivo</title>
+  <meta name="description" content="Búsqueda ejecutiva boutique y selección especializada para empresas de alto crecimiento." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad:clamp(16px,3.2vw,28px);
+      --w:1180px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    body.cookie-modal-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    .muted{color:var(--muted)}
+    .container{max-width:var(--w);margin-inline:auto;padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{width:12px;height:12px;display:block}
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    .topbar{background:#111;color:#fff;font-size:.85rem}
+    .topbar .inner{display:flex;justify-content:space-between;align-items:center;height:40px}
+    .topbar .social a{opacity:.85;margin-left:14px}
+    .topbar .social a:hover{opacity:1}
+
+    .kcvf *{box-sizing:border-box}
+    .kcvf{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:#fff}
+    .kcvf a{color:var(--accent);text-decoration:none}
+    .kcvf a:hover{text-decoration:underline}
+    .kcvf-container{max-width:1100px;margin:0 auto;padding:clamp(20px,4vw,48px)}
+    .kcvf-hero{display:grid;grid-template-columns:1.1fr .9fr;gap:36px;align-items:center;background:linear-gradient(180deg,#fff0%,#f8fafc 100%);border-radius:var(--radius);box-shadow:0 12px 32px rgba(16,24,40,.1);padding:clamp(24px,3vw,40px);position:relative;overflow:hidden}
+    .kcvf-eyebrow{display:inline-flex;align-items:center;gap:8px;background:rgba(10,33,46,.08);color:#0A212E;padding:6px 12px;border-radius:999px;font-weight:600;letter-spacing:.2px;font-size:.9rem}
+    .kcvf-title{font-size:clamp(28px,4.2vw,44px);line-height:1.05;margin:.4rem 0 1rem}
+    .kcvf-title .accent{color:var(--accent)}
+    .kcvf-sub{color:#475569;font-size:clamp(15px,1.4vw,18px);max-width:52ch}
+    .kcvf-hero-cta{display:flex;gap:14px;align-items:center;margin-top:18px;flex-wrap:wrap}
+    .kcvf-badge{display:inline-flex;align-items:center;gap:8px;background:rgba(10,33,46,.08);color:#0A212E;padding:8px 12px;border-radius:12px;font-weight:600;font-size:.95rem}
+    .kcvf-hero img{width:100%;height:auto;border-radius:var(--radius);box-shadow:var(--shadow)}
+    .kcvf-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:34px}
+    .kcvf-card{background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:20px;box-shadow:0 6px 18px rgba(16,24,40,.06)}
+    .kcvf-card h3{margin:.2rem 0 .4rem;font-size:1.05rem}
+    .kcvf-card p{color:var(--muted);font-size:.98rem;line-height:1.55}
+    .kcvf-ico{width:38px;height:38px;border-radius:12px;display:inline-grid;place-items:center;background:rgba(10,33,46,.08);color:#0A212E;margin-bottom:10px}
+    .kcvf-ico svg{stroke:currentColor}
+    .kcvf-steps{margin-top:42px;display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:center}
+    .kcvf-steps ol{counter-reset:step;list-style:none;padding:0;margin:0}
+    .kcvf-steps li{counter-increment:step;background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:16px 16px 16px 58px;position:relative;margin-bottom:12px;box-shadow:0 8px 20px rgba(16,24,40,.05)}
+    .kcvf-steps li:before{content:counter(step);position:absolute;left:16px;top:50%;transform:translateY(-50%);width:32px;height:32px;border-radius:10px;background:var(--accent);color:#fff;display:grid;place-items:center;font-weight:700}
+    .kcvf-steps p{margin:.2rem 0;color:#475569}
+    .kcvf-steps .illus img{width:100%;border-radius:var(--radius);box-shadow:var(--shadow)}
+    .kcvf-formwrap{margin-top:38px;background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:22px;box-shadow:var(--shadow)}
+    .kcvf-formwrap h3{margin:0 0 8px}
+    .kcvf-formwrap p{color:var(--muted)}
+    .kcvf-toggle{margin-top:10px;padding:8px 14px;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;font-weight:600}
+    .kcvf-toggle:hover{filter:brightness(.95)}
+    .kcvf-shortcode{display:none;margin-top:14px;padding:16px;border-radius:12px;background:#f4f6f8;border:1px dashed rgba(10,33,46,.25)}
+    .kcvf-shortcode strong{color:var(--ink)}
+    .kcvf-faq{margin-top:42px;display:grid;grid-template-columns:repeat(2,1fr);gap:18px}
+    .kcvf-faq .q{background:#fff;border:1px solid #e9eef5;border-radius:var(--radius);padding:18px;box-shadow:0 10px 18px rgba(16,24,40,.05)}
+    .kcvf-faq h4{margin:.2rem 0 .3rem}
+
+    footer{background:#0b1220;color:#cbd5e1;padding-block:44px 28px;margin-top:clamp(40px,6vw,80px)}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800;cursor:pointer}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    footer a{color:#cbd5e1}
+
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+      .footer-inner{grid-template-columns:1fr;text-align:center}
+      .newsletter{justify-content:center}
+    }
+
+    @media (max-width:900px){
+      .topbar .inner{flex-direction:column;gap:8px;height:auto;padding-block:8px;text-align:center}
+      .kcvf-hero,.kcvf-steps{grid-template-columns:1fr}
+      .kcvf-grid{grid-template-columns:1fr;gap:14px}
+      .kcvf-faq{grid-template-columns:1fr}
+    }
+
+    @media (max-width:640px){
+      .kcvf-hero{padding:20px}
+      .kcvf-hero-cta{flex-direction:column;align-items:flex-start}
+      .newsletter{flex-direction:column}
+      .newsletter input,
+      .newsletter button{width:100%}
+    }
+  </style>
+</head>
+<body>
+
+
+  <nav class="nav" aria-label="Navegación principal">
+    <div class="container inner">
+      <a class="logo" href="https://kovacictalent.com/"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Logotipo de Kovacic Talent" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Abrir o cerrar la navegación" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menú</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="https://kovacictalent.com/#sectors">Sectores</a>
+          <a href="https://kovacictalent.com/#About">Sobre nosotros</a>
+          <a href="https://kovacictalent.com/#Values">Nuestros valores</a>
+          <a href="https://kovacictalent.com/#process">Cómo trabajamos</a>
+          <a href="https://kovacictalent.com/#processes">Procesos</a>
+          <a href="https://kovacictalent.com/#contact">Contacto</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Enviar CV</a>
+          <a class="btn btn-primary" href="https://kovacictalent.com/#contact">Solicitar una llamada</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent en LinkedIn (se abre en una pestaña nueva)">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="kcvf">
+    <div class="kcvf-container">
+      <section class="kcvf-formwrap" style="margin-top:0">
+        <h3>Registra tu CV para futuras oportunidades</h3>
+        <p>Sube tu CV para que podamos contactarte y mantenerte informado.</p>
+        <button class="kcvf-toggle" id="toggle-cv-form" aria-expanded="false">Registrar CV</button>
+        <div class="kcvf-shortcode" id="cv-form">
+          <strong>[kovacic_cv_register]</strong>
+        </div>
+      </section>
+
+      <header class="kcvf-hero">
+        <div>
+          <span class="kcvf-eyebrow">Desarrollado internamente por Kovacic Executive Talent Research</span>
+          <h1 class="kcvf-title">Potencia el impacto de tu CV <span class="accent"></span></h1>
+          <p class="kcvf-sub">
+            Nuestro sistema analiza tu CV en <strong>múltiples puntos de evaluación</strong>
+            (estructura, impacto, palabras clave, ATS y más) para darte <strong>retroalimentación personalizada</strong>
+            que te ayude a destacar en futuras oportunidades.
+          </p>
+          <div class="kcvf-hero-cta">
+            <span class="kcvf-badge">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M20 7L9 18l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              Retroalimentación clara y accionable
+            </span>
+            <span class="kcvf-badge">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 8v4l3 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/></svg>
+              En cuestión de minutos
+            </span>
+            <span class="kcvf-badge">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4 12h16M4 6h16M4 18h10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+              Compatible con ATS
+            </span>
+          </div>
+        </div>
+        <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_1035652596-scaled.jpeg"
+             alt="Reclutadores profesionales analizando un CV">
+      </header>
+
+      <section class="kcvf-grid" aria-label="Puntos de valor">
+        <article class="kcvf-card">
+          <div class="kcvf-ico">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="7" r="4" stroke="currentColor" stroke-width="2"/></svg>
+          </div>
+          <h3>Personalizado</h3>
+          <p>La retroalimentación se adapta a tu <strong>rol y sector</strong>, resaltando logros y fortalezas relevantes.</p>
+        </article>
+        <article class="kcvf-card">
+          <div class="kcvf-ico">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M3 12h18M3 6h18M3 18h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </div>
+          <h3>Compatible con ATS</h3>
+          <p>Recomendaciones para mejorar la <strong>legibilidad y las palabras clave</strong> sin perder estilo profesional.</p>
+        </article>
+        <article class="kcvf-card">
+          <div class="kcvf-ico">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </div>
+          <h3>Desarrollado internamente</h3>
+          <p>Solución creada por <strong>Kovacic Executive Talent Research</strong> para impulsar tu candidatura.</p>
+        </article>
+      </section>
+
+      <section class="kcvf-steps">
+        <div>
+          <h2>¿Cómo funciona?</h2>
+          <ol>
+            <li>
+              <strong>Sube tu CV y cuéntanos tu objetivo.</strong>
+              <p>Indica el rol/área y el sector para lograr un análisis más preciso.</p>
+            </li>
+            <li>
+              <strong>Analizamos múltiples puntos de evaluación.</strong>
+              <p>Estructura, logros cuantificados, palabras clave, legibilidad y ajuste ATS.</p>
+            </li>
+            <li>
+              <strong>Recibe retroalimentación clara y accionable.</strong>
+              <p><em>Top 5 mejoras</em>, consejos de métricas, revisión sección por sección y un <em>resumen mejorado</em>.</p>
+            </li>
+          </ol>
+        </div>
+        <div class="illus">
+          <img src="https://images.unsplash.com/photo-1551836022-d5d88e9218df?auto=format&fit=crop&w=900&q=80"
+               alt="Ejecutivo revisando un currículum en la oficina">
+        </div>
+      </section>
+
+      <section style="margin-top:36px">
+        <div class="kcvf-card" style="padding:24px">
+          <h2 style="margin:.2rem 0 10px">¿Por qué esta herramienta?</h2>
+          <p style="color:#475569; max-width:80ch">
+            En <strong>Kovacic Executive Talent Research</strong> desarrollamos esta herramienta internamente para ayudarte a
+            <strong>optimizar tu CV</strong> con recomendaciones prácticas. El sistema combina las señales que valoran los reclutadores
+            (claridad, impacto, relevancia, palabras clave y cumplimiento ATS) para ofrecer <strong>retroalimentación personalizada</strong>
+            que mejora tu presentación y posiciona mejor tu candidatura.
+          </p>
+        </div>
+      </section>
+
+      <section class="kcvf-formwrap" id="submit-cv">
+        <h3>Envía tu CV para recibir feedback</h3>
+        <p>Sube tu documento y recibe recomendaciones en pocos minutos.</p>
+        <div class="kcvf-shortcode" style="display:block">
+          <strong>[kovacic_cv_submit]</strong>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Búsqueda ejecutiva y selección de especialistas senior en Tecnología y Energía Renovable. Servicio boutique, alcance global.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('¡Suscripción confirmada!');">
+          <input type="email" required placeholder="Suscríbete con tu correo electrónico">
+          <button type="submit">Suscribirme</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. Todos los derechos reservados · <a href="https://kovacictalent.com/privacy-terms/#privacy">Privacidad</a> · <a href="https://kovacictalent.com/privacy-terms/#terms">Términos</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Tu privacidad es importante</strong>
+      <p id="cookie-banner-desc">Usamos cookies para mantener funciones esenciales, analizar el rendimiento y apoyar el marketing. Puedes actualizar tus preferencias cuando quieras.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Aceptar</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Preferencias de cookies</h2>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Cerrar preferencias de cookies"><span aria-hidden="true">&times;</span></button>
+      </header>
+      <p class="cookie-modal-intro">Decide qué cookies opcionales podemos usar. Las cookies esenciales permanecen activas para garantizar las funciones fundamentales del sitio.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Esenciales</span>
+            <span class="cookie-row-desc">Necesarias para funciones básicas como la navegación, la seguridad y recordar tus preferencias.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analítica</span>
+            <span class="cookie-row-desc">Nos permite entender cómo utilizan esta página los visitantes para mejorar la experiencia.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Nos ayuda a personalizar el contenido y los mensajes según tus intereses.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Guardar preferencias</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const yearTarget = document.getElementById('y');
+    if(yearTarget){
+      yearTarget.textContent = new Date().getFullYear();
+    }
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>
+<!-- /wp:html --></main>
+<!-- /wp:group -->

--- a/page2
+++ b/page2
@@ -173,6 +173,7 @@
     .process-block:first-of-type{margin-top:clamp(18px,3.5vw,32px)}
     .process-header{display:flex;align-items:center;justify-content:space-between;gap:18px;flex-wrap:wrap}
     .process-header .lead{margin:0;text-align:left;flex:1 1 260px}
+    .process-header .lead.lead--center{text-align:center;margin-left:auto;margin-right:auto}
     .process-header .mobile-fold-toggle{margin-top:0}
 
     /* Fixed sector slider — 200px tall and each image spans full width */
@@ -619,7 +620,7 @@
       <h2 class="section-title"><span class="values-title">How We Work</span></h2>
       <div class="process-block">
         <div class="process-header">
-          <p class="lead lead-lg"><strong>Classic Executive Search:</strong> Transparent stages with measurable outcomes, from kickoff to signed offer.</p>
+          <p class="lead lead-lg lead--center"><strong>Classic Executive Search:</strong> Transparent stages with measurable outcomes, from kickoff to signed offer.</p>
           <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#process-classic" aria-expanded="false">
             <span class="fold-label">Read more</span>
             <span class="fold-icon" aria-hidden="true"></span>
@@ -662,7 +663,7 @@
 
       <div class="process-block">
         <div class="process-header">
-          <p class="lead lead-lg"><strong>AI-Enhanced Search:</strong> Blending human expertise with advanced technology to accelerate results.</p>
+          <p class="lead lead-lg lead--center"><strong>AI-Enhanced Search:</strong> Blending human expertise with advanced technology to accelerate results.</p>
           <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#process-ai" aria-expanded="false">
             <span class="fold-label">Read more</span>
             <span class="fold-icon" aria-hidden="true"></span>

--- a/page2_es.html
+++ b/page2_es.html
@@ -1,0 +1,1177 @@
+
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent - Reclutamiento Ejecutivo</title>
+  <meta name="description" content="Boutique executive search & specialist recruitment for high-growth companies." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad: clamp(16px, 3.2vw, 28px);
+      --w: 1180px;            /* content width */
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    .muted{color:var(--muted)}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .container{max-width:var(--w); margin-inline:auto; padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+    .pill{display:inline-flex;align-items:center;gap:.5rem;color:#0f172a;background:linear-gradient(90deg,#eafcf8,#fff);border:1px solid #d9f4ee;padding:.35rem .7rem;border-radius:999px;font-weight:700;font-size:.78rem}
+    .dot{width:8px;height:8px;border-radius:999px;background:#d1d5db}
+    .dot.is-active{background:var(--accent)}
+    /* Navbar */
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{
+      width:12px;
+      height:12px;
+      display:block;
+    }
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{
+      outline:3px solid rgba(10,102,194,.35);
+      outline-offset:2px;
+    }
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    /* HERO */
+    .hero{position:relative;overflow:hidden}
+    .hero .inner{display:grid;grid-template-columns:1.12fr .88fr;align-items:center;gap:48px;padding-block: clamp(20px,4vw,45px)}
+    .eyebrow{font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#475569}
+    h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.08;margin:.35rem 0 1rem}
+    .hero p.sub{color:var(--muted);font-size:1.08rem;max-width:58ch}
+    .cta-row{display:flex;flex-wrap:wrap;gap:12px;margin-top:22px}
+    .hero-copy{position:relative}
+    .hero-slide{display:none}
+    .hero-slide.is-active{display:block}
+    .slider-dots{display:flex;gap:10px;align-items:center;margin-top:28px}
+
+    .hero-visual{position:relative; width:min(45vw,490px); aspect-ratio:1/1; margin-left:auto}
+    .hero-visual .ring{
+      position:absolute; inset:0; border-radius:50%;
+      background: radial-gradient(closest-side,#DDE9F0 0 73%, transparent 73%),
+                  conic-gradient(from 0deg,#f1f5f9, #DDE9F0);
+      z-index:0; opacity:.9; filter:drop-shadow(0 30px 60px rgba(2,6,23,.07));
+    }
+    .hero-visual .photo{
+      position:absolute; inset:12%; border-radius:50%; overflow:hidden; box-shadow:var(--shadow); z-index:1;
+    }
+    .hero-visual .photo img{
+      position:absolute; inset:0; width:100%; height:100%; object-fit:cover; opacity:0; transition:opacity .6s ease;
+    }
+    .hero-visual .photo img.is-active{opacity:1}
+    .hero-visual .badge{
+      position:absolute; right:8%; bottom:10%; z-index:2;
+      background:#fff; border:1px solid var(--line); border-radius:12px;
+      padding:10px 14px; box-shadow:var(--shadow); display:flex; align-items:center; gap:8px;
+      font-weight:700;
+    }
+    .hero-mobile-visual{
+      display:none;
+      width:min(320px,80vw);
+      aspect-ratio:1/1;
+      border-radius:50%;
+      overflow:hidden;
+      margin:16px auto 0;
+      box-shadow:var(--shadow);
+    }
+    .hero-mobile-visual img{
+      width:100%;
+      height:100%;
+      object-fit:cover;
+    }
+    .accent{color:var(--accent)}
+
+    /* Sections */
+    section{padding-block: clamp(24px, 4.5vw, 44px)}
+    .section-title{text-align:center;margin-bottom:8px;font-size:clamp(1.2rem,2.2vw,1.8rem)}
+    .lead{color:var(--muted);text-align:center;max-width:70ch;margin:0 auto 28px}
+    .lead-lg{font-size:1.2rem}
+    .grid{display:grid;gap:22px}
+    .g-3{grid-template-columns:repeat(3,1fr)}
+    .g-4{grid-template-columns:repeat(4,1fr)}
+    .contact-grid{grid-template-columns:1.1fr .9fr;gap:24px}
+    .card{background:#fafafa;border:1px solid var(--line);border-radius:var(--radius);padding:20px}
+    .card h3{margin:8px 0 6px}
+    .icon{width:36px;height:36px;border-radius:10px;background:linear-gradient(180deg,#eafff9,#fff);border:1px solid #d9f4ee;display:grid;place-items:center}
+    #process .card svg,
+    #process-ai .card svg{width:32px;height:32px;color:var(--accent);margin-bottom:12px}
+    #process .process-alt{margin-top:clamp(32px,5vw,60px)}
+
+    .values-title{position:relative;display:inline-block;padding-bottom:8px}
+    .values-title::after{content:"";position:absolute;left:0;bottom:0;width:100%;height:4px;background-color:#0A212E}
+    .values-grid{grid-template-columns:repeat(6,1fr)}
+    .values-grid .card{grid-column:span 2}
+    .values-grid .card:nth-child(4){grid-column:2/span 2}
+    .values-grid .card:nth-child(5){grid-column:4/span 2}
+
+    .why-choose{text-align:center}
+    .why-choose ul{list-style:none;margin:12px auto 0;padding:0;display:grid;gap:10px;max-width:520px;text-align:left}
+    .why-choose li{position:relative;padding-left:32px;color:var(--ink);font-weight:500;line-height:1.6}
+    .why-choose li::before{content:"✔️";position:absolute;left:0;top:0}
+
+    .process-block{margin-top:clamp(26px,4vw,44px)}
+    .process-block:first-of-type{margin-top:clamp(18px,3.5vw,32px)}
+    .process-header{display:flex;align-items:center;justify-content:space-between;gap:18px;flex-wrap:wrap}
+    .process-header .lead{margin:0;text-align:left;flex:1 1 260px}
+    .process-header .mobile-fold-toggle{margin-top:0}
+
+    /* Fixed sector slider — 200px tall and each image spans full width */
+    .sector-slider{
+      position:relative;
+      overflow:hidden;
+      margin-top:30px;
+      border-radius:var(--radius);
+      box-shadow:var(--shadow);
+      height:200px;
+      width:100%;
+    }
+    .sector-track{
+      display:flex;
+      height:100%;
+      width:100%;
+    }
+      .sector-track img{
+        flex:0 0 100%;
+        width:100%;
+        height:100%;
+        object-fit:cover;   /* fill left→right; crop if needed */
+        object-position:center;
+      }
+
+    /* About */
+    .about-section{padding-block:clamp(36px,6vw,86px)}
+    .about-grid{
+      display:grid;
+      grid-template-columns:minmax(0,0.9fr) minmax(0,1.1fr);
+      gap:clamp(28px,6vw,60px);
+      align-items:start;
+      grid-template-areas:
+        "visual content"
+        "details details";
+    }
+    .about-visual{grid-area:visual;position:relative;width:min(420px,42vw);aspect-ratio:1/1;margin:0 auto 0 0}
+    .about-visual .ring{
+      position:absolute;
+      inset:0;
+      border-radius:50%;
+      background: radial-gradient(closest-side,#DDE9F0 0 73%, transparent 73%),
+                  conic-gradient(from 0deg,#f1f5f9, #DDE9F0);
+      z-index:0;
+      opacity:.9;
+      filter:drop-shadow(0 30px 60px rgba(2,6,23,.07));
+    }
+    .about-visual .photo{position:absolute;inset:12%;border-radius:50%;overflow:hidden;box-shadow:var(--shadow);z-index:1}
+    .about-visual .photo img{width:100%;height:100%;object-fit:cover}
+    .about-content{grid-area:content;display:grid;gap:clamp(16px,2.6vw,22px);align-content:start}
+    .about-content .section-title{text-align:left;margin-bottom:4px}
+    .about-content h3{margin:0;font-size:1.1rem;color:var(--accent)}
+    .about-details{grid-area:details;display:grid;gap:clamp(16px,2.8vw,24px);align-content:start;margin-top:0}
+    .about-content ul,
+    .about-details ul{list-style:none;margin:0;padding:0;display:grid;gap:8px;color:var(--ink)}
+    .about-content li,
+    .about-details li{line-height:1.6}
+    .about-content li strong,
+    .about-details li strong{color:var(--accent)}
+    .about-content p,
+    .about-details p{color:var(--muted)}
+    .about-lead{margin:0;color:var(--ink);font-weight:600}
+    .about-locations{margin:0;font-weight:600;color:var(--ink)}
+    .about-locations strong{color:var(--accent)}
+
+    .mobile-fold-toggle{display:none;align-items:center;justify-content:center;gap:8px;padding:.45rem .85rem;border-radius:999px;border:1px solid var(--line);background:#fff;font-weight:600;font-size:.85rem;color:var(--accent);cursor:pointer;margin-top:8px;transition:background .2s ease,border-color .2s ease,color .2s ease}
+    .mobile-fold-toggle.fold-center{justify-content:center;margin-inline:auto}
+    .mobile-fold-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .mobile-fold-toggle:focus-visible{outline:3px solid rgba(10,33,46,.3);outline-offset:3px}
+    .mobile-fold-toggle .fold-icon{width:22px;height:22px;border:1px solid currentColor;border-radius:999px;display:grid;place-items:center;font-size:.85rem;font-weight:700;line-height:1}
+    .mobile-fold-toggle .fold-icon::before{content:"+";transform:translateY(-1px)}
+    .mobile-fold-toggle.is-expanded .fold-icon::before{content:"–"}
+    .mobile-fold-toggle.is-expanded{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .mobile-fold-toggle.is-expanded .fold-icon{border-color:#fff}
+    .mobile-fold-content{margin-top:clamp(14px,2vw,20px)}
+    .about-details.mobile-fold-content{margin-top:0}
+
+      /* Testimonials */
+      .testis{background:#f6f8fb;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+    .section-beige{background:var(--beige);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+    blockquote{max-width:860px;margin:0 auto;padding:0 20px;font-size:1.1rem;line-height:1.6;text-align:center;color:#0f172a}
+    cite{display:block;margin-top:10px;color:#475569;font-style:normal;font-weight:700}
+
+    /* Footer */
+    footer{background:#0b1220;color:#cbd5e1}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+
+    /* Cookie consent */
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+    body.cookie-modal-open{overflow:hidden}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    /* Responsive */
+      @media (max-width: 980px){
+        .menu-toggle{display:inline-flex}
+        .hero .inner{grid-template-columns:1fr;text-align:center}
+        .hero .hero-copy{max-width:560px;margin:0 auto}
+        .hero p.sub{margin-inline:auto}
+        .hero-visual{margin:0 auto;overflow:hidden}
+        .hero-visual .ring{right:-40vw;top:-28vw}
+        .hero-visual .photo{margin-inline:auto}
+        .footer-inner{grid-template-columns:1fr}
+        .about-grid{
+          grid-template-columns:1fr;
+          grid-template-areas:
+            "visual"
+            "content"
+            "details";
+        }
+        .about-visual{margin:0 auto;width:min(320px,80vw)}
+        .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+        .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+        .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+        .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+        .menu a:first-child{border-top:none}
+        .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+        .nav-cta .btn{width:100%;justify-content:center}
+      }
+
+      @media (max-width: 640px){
+        .hero .hero-slide{text-align:center}
+        .hero .hero-slide > *{margin-left:auto;margin-right:auto}
+        .cta-row{flex-direction:column}
+        .cta-row .btn{width:100%;justify-content:center}
+        .slider-dots{justify-content:center}
+        .grid{grid-template-columns:1fr !important}
+        .values-grid{grid-template-columns:1fr !important}
+        .values-grid .card{grid-column:auto !important}
+        .mobile-two-cols{grid-template-columns:repeat(2,minmax(0,1fr)) !important;gap:16px}
+        .mobile-two-cols .card{padding:16px;font-size:.92rem}
+        .mobile-two-cols .card h3{font-size:1rem}
+        .mobile-two-cols .card p{font-size:.92rem;line-height:1.55}
+        .mobile-two-cols .card > strong{display:block;font-size:.9rem;margin-bottom:6px}
+        .mobile-fold-toggle{display:inline-flex}
+        .mobile-fold-toggle.fold-center{display:flex}
+        .mobile-fold-content{display:none}
+        .mobile-fold-content.is-open{display:block}
+        .process-header{gap:12px;flex-direction:column;align-items:center;text-align:center}
+        .process-header .lead{flex:unset;text-align:center}
+        .process-header .mobile-fold-toggle{width:auto;align-self:center}
+        .hero-visual{display:none}
+        .hero-visual .ring{display:none}
+        .hero-visual .photo{inset:0}
+        .hero-mobile-visual{display:block}
+        .contact-grid{grid-template-columns:1fr !important}
+        .about-content .section-title{text-align:center}
+        .about-content,
+        .about-content > *,
+        .about-content ul,
+        .about-content li,
+        .about-content p,
+        .about-content h3,
+        .about-details,
+        .about-details > *,
+        .about-details ul,
+        .about-details li,
+        .about-details p{
+          text-align:center;
+        }
+        .grid .card,
+        .grid .card > *,
+        .grid .card h3,
+        .grid .card p,
+        .grid .card strong{
+          text-align:center;
+        }
+        .why-choose,
+        .why-choose h3,
+        .why-choose ul,
+        .why-choose li{
+          text-align:center;
+        }
+        .why-choose ul{justify-items:center}
+        .contact-grid .card,
+        .contact-grid .card > *,
+        #contact .card > div{
+          text-align:center;
+        }
+        #contact .card > div{justify-content:center}
+        footer .footer-inner,
+        footer .footer-inner > *,
+        footer .mini{
+          text-align:center;
+        }
+        .newsletter{justify-content:center}
+      }
+  </style>
+</head>
+<body>
+  <!-- Navigation -->
+  <nav class="nav" aria-label="Primary navigation">
+    <div class="container inner">
+      <a class="logo" href="#"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menú</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="#sectors">Sectores</a>
+          <a href="#About">Sobre nosotros</a>
+          <a href="#Values">Nuestros valores</a>
+          <a href="#process">Cómo trabajamos</a>
+          <a href="#processes">Procesos</a>
+          <a href="#contact">Contacto</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Enviar CV</a>
+          <a class="btn btn-primary" href="#contact">Solicitar una llamada</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent on LinkedIn (opens in a new tab)">
+            <svg viewbox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- HERO -->
+  <header class="hero">
+    <div class="container inner">
+      <div class="hero-copy">
+        <div class="hero-slide is-active">
+          <h1>Conectamos talento con la energía del cambio</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_641731816-scaled.jpeg" alt="Senior professional meeting in modern office">
+          </div>
+          <span class="pill">Más de 10 años de experiencia</span>
+          <h1>Somos un <span class="accent">partner de reclutamiento</span> para empresas de alto crecimiento</h1>
+          <p class="sub">Ayudamos a organizaciones de EMEA y LATAM a identificar y atraer líderes y especialistas senior excepcionales, combinando métodos de búsqueda rigurosos con IA moderna y ética para ofrecer resultados que perduran.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="#contact">Inicia tu búsqueda</a>
+            <a class="btn btn-ghost" href="#process">Ver nuestro proceso</a>
+          </div>
+        </div>
+        <div class="hero-slide">
+          <h1>Conectamos talento con la energía del cambio</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://images.unsplash.com/photo-1551836022-4c4c79ecde51?q=80&w=1200&auto=format&fit=crop" alt="Executive handshake in office">
+          </div>
+          <span class="pill">Resultados que perduran</span>
+          <h1>85% de retención a 12 meses</h1>
+          <p class="sub">Nuestros placements prosperan a largo plazo: cuatro de cada cinco líderes continúan en el cargo tras el primer año.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="#process">Ver nuestro proceso</a>
+            <a class="btn btn-ghost" href="#contact">Inicia tu búsqueda</a>
+          </div>
+        </div>
+        <div class="hero-slide">
+          <h1>Conectamos talento con la energía del cambio</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_1035652596-scaled.jpeg?q=80&w=1200&auto=format&fit=crop" alt="Team collaboration at work">
+          </div>
+          <span class="pill">Mejora tu CV</span>
+          <h1>Feedback personal y compatible con ATS</h1>
+          <p class="sub">Sube tu CV para recibir sugerencias claras y accionables adaptadas a tu rol y sector.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="http://www.kovacictalent.com/mejoracv">Mejorar mi CV</a>
+            <a class="btn btn-ghost" href="#contact">Inicia tu búsqueda</a>
+          </div>
+        </div>
+        <div class="slider-dots" aria-label="Hero carousel navigation">
+          <span class="dot is-active" aria-hidden="true"></span>
+          <span class="dot" aria-hidden="true"></span>
+          <span class="dot" aria-hidden="true"></span>
+        </div>
+      </div>
+
+      <div class="hero-visual">
+        <div class="ring" aria-hidden="true"></div>
+        <div class="photo">
+          <img class="is-active" src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_641731816-scaled.jpeg" alt="Senior professional meeting in modern office">
+          <img src="https://images.unsplash.com/photo-1551836022-4c4c79ecde51?q=80&w=1200&auto=format&fit=crop" alt="Executive handshake in office">
+          <img src="https://kovacictalent.com/wp-content/uploads/2025/05/AdobeStock_1035652596-scaled.jpeg?q=80&w=1200&auto=format&fit=crop" alt="Team collaboration at work">
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- SECTORS -->
+  <section id="sectors" class="section-beige">
+    <div class="container">
+      <h2 class="section-title"><span class="values-title">Sectores</span></h2>
+      <p class="lead">Redes profundas en tecnología y energía renovable, además de industrias adyacentes.</p>
+      <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#sectors-fold" aria-expanded="false">
+        <span class="fold-label">Leer más</span>
+        <span class="fold-icon" aria-hidden="true"></span>
+      </button>
+      <div class="mobile-fold-content" id="sectors-fold">
+        <div class="grid g-4">
+          <div class="card"><h3>Tecnología</h3><p>Ingeniería, datos, seguridad, producto y plataforma.</p></div>
+          <div class="card"><h3>Energías renovables</h3><p>Solar, eólica, BESS, red e hidrógeno.</p></div>
+          <div class="card"><h3>Servicios financieros</h3><p>PE/VC, project finance y gestión de activos.</p></div>
+          <div class="card"><h3>Industrial y operaciones</h3><p>EPC, cadena de suministro y liderazgo de operaciones.</p></div>
+        </div>
+        <div class="sector-slider">
+          <div class="sector-track">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/8478.jpg" alt="Technology sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/landscape-with-windmills-scaled.jpg" alt="Renewable energy sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/template_21-scaled.png" alt="Financial services sector">
+            <img src="https://kovacictalent.com/wp-content/uploads/2025/09/large-vecteezy_confident-factory-worker-using-digital-tablet-in-industrial_47268909_large.jpg" alt="Industrial operations sector">
+          </div>
+        </div>
+      </div>
+    </div>
+    </section>
+
+    <!-- ABOUT -->
+    <section id="About" class="about-section">
+      <div class="container">
+        <div class="about-grid">
+          <div class="about-visual">
+            <div class="ring" aria-hidden="true"></div>
+            <div class="photo">
+              <img src="https://kovacictalent.com/wp-content/uploads/2025/09/Alan2.png" alt="Senior professional meeting in modern office">
+            </div>
+          </div>
+          <div class="about-content">
+            <h2 class="section-title"><span class="values-title">Sobre nosotros</span></h2>
+            <p class="about-intro">En Kovacic somos una firma joven respaldada por un equipo con décadas de experiencia en búsqueda ejecutiva internacional. Adoptamos un modelo boutique donde la tecnología de vanguardia y la inteligencia artificial potencian nuestros procesos con mayor precisión y agilidad, siempre como complemento de lo más importante: la visión humana y la relación cercana con ejecutivos y candidatos.</p>
+            <p class="about-lead">Nuestra identidad se expresa a través de dos marcas:</p>
+            <ul>
+              <li><strong>Kovacic Talent</strong>, enfocada en posiciones técnicas, mandos medios y profesionales clave que sostienen el crecimiento.</li>
+              <li><strong>Kovacic Executive</strong>, especializada en la búsqueda de líderes senior, ejecutivos y miembros de consejo con visión global.</li>
+            </ul>
+            <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#about-fold" aria-expanded="false">
+              <span class="fold-label">Leer más</span>
+              <span class="fold-icon" aria-hidden="true"></span>
+            </button>
+          </div>
+          <div class="about-details mobile-fold-content" id="about-fold">
+
+            <p class="about-lead">Nuestras principales divisiones:</p>
+            <ul>
+              <li>🔹 <strong>Executive Search & Talent Acquisition</strong> – Reclutamiento de liderazgo estratégico y técnico.</li>
+              <li>🔹 <strong>Board & Governance</strong> – Selección de consejeros y advisory boards con experiencia internacional.</li>
+              <li>🔹 <strong>Leadership Development</strong> – Planificación de sucesión, programas de liderazgo y executive coaching.</li>
+              <li>🔹 <strong>Market Intelligence</strong> – Mapeo de talento, benchmarking y análisis de mercado.</li>
+            </ul>
+            <p>Dentro de estas divisiones operamos en sectores clave: finanzas, infraestructura, tecnología, laboratorios, hospitality, minería y energía, con un equipo de especialistas dedicado en cada área que garantiza un profundo conocimiento del sector y procesos altamente efectivos.</p>
+            <p>Nuestro valor no solo está en identificar talento, sino en ser un partner cercano que genera un impacto positivo en el mercado laboral. Trabajamos cada día en la mejora continua y en ofrecer una experiencia diferencial para candidatos y clientes, construyendo confianza, generando resultados concretos y contribuyendo al crecimiento a largo plazo.</p>
+            <p class="about-locations">Nuestras fortalezas en desarrollo de talento se apoyan en los hubs de negocio más influyentes del mundo: Nueva York, París, Madrid, Barcelona, Berlín, Roma, Ámsterdam, Oslo, Estocolmo, Ciudad de México, São Paulo, Santiago de Chile, Lima, Panamá, Shanghái y Hong Kong.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- VALUES -->
+    <section id="Values" class="container">
+    <h2 class="section-title"><span class="values-title">Nuestros valores</span></h2>
+    <p class="lead" style="text-align: center; max-width: 800px; margin: 20px auto;">
+      En <strong>Kovacic Executive Talent Research</strong>, nuestros valores guían todo lo que hacemos.
+      Definen <strong>cómo trabajamos</strong>, cómo construimos <strong>relaciones</strong> y cómo generamos
+      un <strong>impacto duradero</strong> para nuestros clientes y candidatos.
+    </p>
+    <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#values-fold" aria-expanded="false">
+      <span class="fold-label">Leer más</span>
+      <span class="fold-icon" aria-hidden="true"></span>
+    </button>
+      <div class="mobile-fold-content" id="values-fold">
+      <div class="grid values-grid">
+      <div class="card">
+        <h3>Excelencia</h3>
+        <p>Nos comprometemos con los <strong>más altos estándares</strong> en cada etapa del proceso, entregando resultados que generan <strong>un impacto real</strong> en las organizaciones.</p>
+      </div>
+      <div class="card">
+        <h3>Confianza</h3>
+        <p>Construimos <strong>relaciones sólidas y duraderas</strong> basadas en <strong>la transparencia</strong>, el respeto y la confidencialidad.</p>
+      </div>
+      <div class="card">
+        <h3>Visión humana</h3>
+        <p>Creemos en el <strong>poder transformador del liderazgo</strong>. Buscamos talento que <strong>inspira, moviliza</strong> y construye <strong>culturas sostenibles</strong>.</p>
+      </div>
+      <div class="card">
+        <h3>Perspectiva global</h3>
+        <p>Operamos <strong>sin fronteras</strong>, combinando una <strong>visión internacional</strong> con un profundo entendimiento de <strong>los contextos locales</strong>.</p>
+      </div>
+      <div class="card">
+        <h3>Adaptabilidad</h3>
+        <p>Respondemos con <strong>agilidad</strong> al cambio, reconociendo que cada organización es <strong>única</strong> y requiere <strong>soluciones a medida</strong>.</p>
+      </div>
+    </div>
+    </div>
+    </section>
+
+  <!-- PROCESS -->
+  <section id="process" class="section-beige">
+    <div class="container">
+      <h2 class="section-title"><span class="values-title">Cómo trabajamos</span></h2>
+      <div class="process-block">
+        <div class="process-header">
+          <p class="lead lead-lg"><strong>Búsqueda Ejecutiva Clásica:</strong> Etapas transparentes con resultados medibles, desde el inicio hasta la oferta firmada.</p>
+          <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#process-classic" aria-expanded="false">
+            <span class="fold-label">Leer más</span>
+            <span class="fold-icon" aria-hidden="true"></span>
+          </button>
+        </div>
+        <div class="mobile-fold-content" id="process-classic">
+          <div class="grid g-4 mobile-two-cols">
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...></svg>
+              <strong>01 • Discovery</strong>
+              <p>Profundización en el perfil de éxito, encaje cultural, rasgos de liderazgo y contexto del rol.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...></svg>
+              <strong>02 • Mapping</strong>
+              <p>Investigación manual de mercado, headhunting directo y construcción de una longlist validada.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...></svg>
+              <strong>03 • Shortlist</strong>
+              <p>Entrevistas estructuradas, evaluaciones detalladas y reportes de avance semanales.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...></svg>
+              <strong>04 • Close</strong>
+              <p>Estrategia de oferta, alineación de expectativas y acompañamiento en el onboarding.</p>
+            </div>
+          </div>
+          <div class="why-choose">
+            <h3>¿Por qué elegir la modalidad clásica?</h3>
+            <ul>
+              <li>Ideal para roles altamente confidenciales o de nicho donde la confianza y la discreción son fundamentales.</li>
+              <li>Se apoya en redes humanas profundas, relaciones y prácticas de headhunting comprobadas.</li>
+              <li>Garantiza el alineamiento cultural mediante una validación personal rigurosa en cada etapa.</li>
+              <li>Perfecto cuando la precisión, la experiencia y el criterio personalizado pesan más que la velocidad.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="process-block">
+        <div class="process-header">
+          <p class="lead lead-lg"><strong>Búsqueda potenciada con IA:</strong> Combinamos la experiencia humana con tecnología avanzada para acelerar los resultados.</p>
+          <button class="mobile-fold-toggle fold-center" type="button" data-fold-target="#process-ai" aria-expanded="false">
+            <span class="fold-label">Leer más</span>
+            <span class="fold-icon" aria-hidden="true"></span>
+          </button>
+        </div>
+        <div class="process-alt mobile-fold-content" id="process-ai">
+          <div class="grid g-4 mobile-two-cols">
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...></svg>
+              <strong>01 • Discovery</strong>
+              <p>Perfil de éxito, señales culturales, cronograma y <strong>calibración del rol basada en IA</strong>.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...></svg>
+              <strong>02 • Mapping</strong>
+              <p><strong>Exploración del mercado impulsada por IA + validación humana</strong>, para entregar una longlist más inteligente con mayor rapidez.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...></svg>
+              <strong>03 • Shortlist</strong>
+              <p>Entrevistas estructuradas, scorecards predictivos y paneles en vivo con <strong>insights semanales impulsados por IA</strong>.</p>
+            </div>
+            <div class="card">
+              <svg viewbox="0 0 24 24" ...></svg>
+              <strong>04 • Close</strong>
+              <p>Estrategia de oferta, alineación de expectativas, soporte en onboarding, <strong>más insights de retención continuos basados en datos</strong>.</p>
+            </div>
+          </div>
+          <div class="why-choose">
+            <h3>¿Por qué elegir la modalidad potenciada con IA?</h3>
+            <ul>
+              <li>Acelera la búsqueda con datos en tiempo real y mapeo de talento potenciado por IA.</li>
+              <li>Descubre pools de talento ocultos en geografías e industrias más amplias.</li>
+              <li>Ofrece insights medibles a través de scorecards, dashboards y analítica.</li>
+              <li>Perfecto cuando necesitas escalabilidad, transparencia y decisiones más rápidas.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- INSIGHTS -->
+  <section id="processes" class="container">
+    <h2 class="section-title"><span class="values-title">Últimos procesos</span></h2>
+    <p class="lead">Los procesos publicados más recientes</p>
+<div style="margin:1rem 0; text-align:center;">
+  <a class="btn btn-primary" href="https://kovacictalent.com/procesos-activos/">Más oportunidades</a>
+</div>
+
+    <div id="blog-posts" class="grid g-3"></div>
+  </section>
+
+  <!-- CONTACT / CTA -->
+  <section id="contact" class="container">
+    <h2 class="section-title"><span class="values-title">¿Listo para comenzar?</span></h2>
+    <p class="lead">Cuéntanos cómo se ve el éxito y diseñaremos una búsqueda a su alrededor.</p>
+    <div class="grid contact-grid">
+      <div class="card" style="display:grid;gap:10px">
+        <p class="muted">Nos encantará saber de ti; despliega abajo para enviarnos un mensaje.</p>
+        <details>
+          <summary style="cursor:pointer;font-weight:600">Abrir formulario de contacto</summary>
+          [contact-form-7 id="e7e9470" title="Sin título"]
+        </details>
+      </div>
+      <div class="card" style="display:grid;gap:10px">
+        <h3>Contacto</h3>
+        <p class="muted">📞 +34 611 897 294<br>✉️ info@kovacictalent.com<br>📍 Madrid · Barcelona · Santiago</p>
+        <div style="display:flex;gap:10px;align-items:center">
+          <span class="pill">Shortlist promedio en 12 días</span>
+          <span class="pill">Alcance global</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Búsqueda ejecutiva y selección de especialistas senior en Tecnología y Energía Renovable. Servicio boutique, alcance global.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
+          <input type="email" required placeholder="Subscribe with your email">
+          <button type="submit">Suscribirme</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. Todos los derechos reservados · <a href="https://kovacictalent.com/privacy-terms/#privacy" style="color:#cbd5e1">Privacidad</a> · <a href="https://kovacictalent.com/privacy-terms/#terms" style="color:#cbd5e1">Términos</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Tu privacidad es importante</strong>
+      <p id="cookie-banner-desc">Usamos cookies para mantener la fiabilidad del sitio, entender el rendimiento y personalizar el marketing. Ajusta tus preferencias en cualquier momento.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Aceptar</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Preferencias de cookies</h2>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Close cookie preferences"><span aria-hidden="true">×</span></button>
+      </header>
+      <p class="cookie-modal-intro">Controla cómo usamos las cookies opcionales. Las cookies esenciales siempre están activas para que el sitio funcione correctamente.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Esenciales</span>
+            <span class="cookie-row-desc">Necesarias para la navegación, la seguridad y guardar tus elecciones.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analítica</span>
+            <span class="cookie-row-desc">Nos ayuda a entender el tráfico del sitio para aplicar mejoras continuas.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Permite personalizar el contenido y medir la efectividad de las campañas.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Guardar preferencias</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+
+    /* Mobile navigation */
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+
+    /* Hero carousel */
+    (function(){
+      const slides = document.querySelectorAll('.hero-visual .photo img');
+      const dots = document.querySelectorAll('.slider-dots .dot');
+      const copies = document.querySelectorAll('.hero-slide');
+      let idx = 0;
+      function show(n){
+        slides[idx].classList.remove('is-active');
+        dots[idx].classList.remove('is-active');
+        copies[idx].classList.remove('is-active');
+        idx = n;
+        slides[idx].classList.add('is-active');
+        dots[idx].classList.add('is-active');
+        copies[idx].classList.add('is-active');
+      }
+      function next(){ show((idx + 1) % slides.length); }
+      let timer = setInterval(next, 15000);
+      dots.forEach((dot,i)=>dot.addEventListener('click',()=>{show(i); clearInterval(timer); timer=setInterval(next,15000);}));      
+      // Initialize first text slide visible
+      copies[0].classList.add('is-active');
+    })();
+
+    /* Sector slider (each image = full width, 200px tall) */
+    (function(){
+      const slider = document.querySelector('.sector-slider');
+      if(!slider) return;
+      const track = slider.querySelector('.sector-track');
+      if(!track.children.length) return;
+
+      // Clone first slide for smooth loop
+      const first = track.children[0].cloneNode(true);
+      track.appendChild(first);
+
+      let sIdx = 0;
+      const duration = 600;
+      const intervalMs = 10000;
+
+      function step(){
+        sIdx++;
+        const slideWidth = slider.clientWidth;
+        track.style.transition = 'transform .6s ease';
+        track.style.transform = `translateX(-${sIdx * slideWidth}px)`;
+        if(sIdx === track.children.length - 1){
+          setTimeout(()=>{
+            track.style.transition = 'none';
+            track.style.transform = 'translateX(0)';
+            sIdx = 0;
+          }, duration);
+        }
+      }
+
+      let t = setInterval(step, intervalMs);
+      // Reset transform on resize to keep widths perfect
+      window.addEventListener('resize', ()=>{
+        track.style.transition = 'none';
+        track.style.transform = `translateX(-${sIdx * slider.clientWidth}px)`;
+      });
+    })();
+
+    /* Mobile fold controls */
+    (function(){
+      const toggles = document.querySelectorAll('[data-fold-target]');
+      if(!toggles.length) return;
+      const mobileQuery = window.matchMedia('(max-width: 640px)');
+      const defaultLabel = 'Read more';
+      const expandedLabel = 'Show less';
+
+      const sync = () => {
+        toggles.forEach(btn => {
+          const target = document.querySelector(btn.dataset.foldTarget);
+          if(!target) return;
+          const expanded = btn.getAttribute('aria-expanded') === 'true';
+          const label = btn.querySelector('.fold-label');
+          if(mobileQuery.matches){
+            target.classList.toggle('is-open', expanded);
+            btn.classList.toggle('is-expanded', expanded);
+            if(label) label.textContent = expanded ? expandedLabel : defaultLabel;
+          } else {
+            target.classList.add('is-open');
+            btn.setAttribute('aria-expanded','true');
+            btn.classList.remove('is-expanded');
+            if(label) label.textContent = defaultLabel;
+          }
+        });
+      };
+
+      toggles.forEach(btn => {
+        btn.addEventListener('click', () => {
+          if(!mobileQuery.matches) return;
+          const expanded = btn.getAttribute('aria-expanded') === 'true';
+          btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+          sync();
+        });
+      });
+
+      mobileQuery.addEventListener('change', event => {
+        if(event.matches){
+          toggles.forEach(btn => btn.setAttribute('aria-expanded','false'));
+        }
+        sync();
+      });
+
+      sync();
+    })();
+
+    /* Load latest blog posts */
+    (async function(){
+      const container = document.getElementById('blog-posts');
+      if(!container) return;
+      try{
+        const res = await fetch('https://kovacictalent.com/wp-json/wp/v2/posts?per_page=3&_embed');
+        const posts = await res.json();
+        posts.forEach(p=>{
+          const img = p._embedded && p._embedded['wp:featuredmedia'] ? p._embedded['wp:featuredmedia'][0].source_url : '';
+          const article = document.createElement('article');
+          article.className = 'card';
+          const excerpt = p.excerpt.rendered.replace(/<[^>]+>/g,'').slice(0,140);
+          article.innerHTML = `
+            ${img ? `<img src="${img}" alt="${p.title.rendered}" style="width:100%;height:160px;object-fit:cover;border-radius:var(--radius);">` : ''}
+            <h3>${p.title.rendered}</h3>
+            <p>${excerpt}</p>
+            <a href="${p.link}" style="color:var(--accent);font-weight:600;">Read more..</a>
+          `;
+          container.appendChild(article);
+        });
+      }catch(err){
+        console.error('Failed to load posts', err);
+      }
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>

--- a/terms_es.html
+++ b/terms_es.html
@@ -1,0 +1,755 @@
+
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kovacic Talent — Política de Privacidad y Términos</title>
+  <meta name="description" content="Centro legal de Kovacic Talent con la política de privacidad y los términos de servicio." />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --ink:#101828;
+      --muted:#667085;
+      --bg:#ffffff;
+      --accent:#0A212E;
+      --accent-dark:#0A212E;
+      --line:#ebedf0;
+      --beige:#E9F0F5;
+      --shadow:0 10px 30px rgba(16,24,40,.08);
+      --radius:14px;
+      --radius-lg:22px;
+      --pad:clamp(16px,3.2vw,28px);
+      --w:1180px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;overflow-x:hidden}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;color:var(--ink);background:var(--bg);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+    body.nav-open{overflow:hidden}
+    a{color:inherit;text-decoration:none}
+    a:hover{text-decoration:none;color:var(--accent)}
+    img{max-width:100%;display:block}
+    p{margin:0 0 1rem}
+    ul{margin:0 0 1.3rem 1.25rem;padding:0}
+    li{margin:0 0 .55rem}
+    strong{font-weight:700}
+    .muted{color:var(--muted)}
+    .container{max-width:var(--w);margin-inline:auto;padding-inline:var(--pad)}
+    .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.9rem 1.3rem;border-radius:999px;font-weight:700;letter-spacing:.01em}
+    .btn-primary{background:#111;color:#fff}
+    .btn-primary:hover{filter:brightness(.95)}
+    .btn-ghost{border:2px solid #111;color:#111}
+    .btn-ghost:hover{background:#111;color:#fff}
+    .pill{display:inline-flex;align-items:center;gap:.5rem;color:#0f172a;background:linear-gradient(90deg,#eafcf8,#fff);border:1px solid #d9f4ee;padding:.35rem .7rem;border-radius:999px;font-weight:700;font-size:.78rem;text-transform:uppercase;letter-spacing:.1em}
+
+    /* Navbar */
+    .nav{position:sticky;top:0;z-index:40;background:#fff;border-bottom:1px solid var(--line);backdrop-filter:blur(8px)}
+    .nav .inner{display:flex;align-items:center;justify-content:space-between;gap:18px;height:60px;position:relative}
+    .logo{display:flex;align-items:center;gap:.5rem;font-weight:900;letter-spacing:.02em}
+    .logo-img{height:32px;width:auto}
+    .menu-panel{display:flex;align-items:center;gap:20px;margin-left:auto;position:relative}
+    .menu{display:flex;gap:20px;align-items:center;flex-wrap:nowrap}
+    .menu a{font-weight:600;color:#0f172a;transition:color .2s ease;font-size:.93rem;white-space:nowrap}
+    .menu a:hover{color:var(--accent-dark)}
+    .nav-cta{display:flex;gap:8px;align-items:center}
+    .nav-cta .btn{white-space:nowrap;padding:.6rem .95rem;font-size:.85rem}
+    .nav-cta .nav-linkedin{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:24px;
+      height:24px;
+      min-width:24px;
+      border-radius:50%;
+      border:1px solid #0A66C2;
+      color:#0A66C2;
+      background:#fff;
+      transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease;
+    }
+    .nav-cta .nav-linkedin svg{width:12px;height:12px;display:block}
+    .nav-cta .nav-linkedin:hover{
+      background:#0A66C2;
+      color:#fff;
+      border-color:#0A66C2;
+      box-shadow:0 4px 12px rgba(10,102,194,.22);
+    }
+    .nav-cta .nav-linkedin:focus-visible{outline:3px solid rgba(10,102,194,.35);outline-offset:2px}
+    .menu-toggle{display:none;align-items:center;gap:10px;padding:.65rem .9rem;border-radius:12px;border:1px solid var(--line);background:#fff;font-weight:600;color:var(--ink);cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .menu-toggle:hover{background:var(--beige);border-color:#d0d8dd}
+    .menu-toggle:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:3px}
+    .menu-label{font-size:.95rem}
+    .menu-icon{position:relative;width:18px;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,background .2s ease}
+    .menu-icon::before,
+    .menu-icon::after{content:"";position:absolute;left:0;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .2s ease,opacity .2s ease}
+    .menu-icon::before{top:-6px}
+    .menu-icon::after{top:6px}
+    .nav.is-open .menu-toggle{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .nav.is-open .menu-icon{background:transparent}
+    .nav.is-open .menu-icon::before{transform:translateY(6px) rotate(45deg)}
+    .nav.is-open .menu-icon::after{transform:translateY(-6px) rotate(-45deg)}
+
+    /* HERO */
+    .hero{position:relative;overflow:hidden}
+    .hero .inner{display:grid;grid-template-columns:1.12fr .88fr;align-items:center;gap:48px;padding-block:clamp(36px,5vw,72px)}
+    .eyebrow{font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#475569}
+    h1{font-size:clamp(2rem,4vw,3.2rem);line-height:1.08;margin:.35rem 0 1rem}
+    h2{font-size:clamp(1.4rem,2.5vw,2rem);line-height:1.18;margin:0 0 1rem}
+    h3{font-size:1.15rem;margin:1.8rem 0 .7rem}
+    .hero p.sub{color:var(--muted);font-size:1.08rem;max-width:58ch}
+    .cta-row{display:flex;flex-wrap:wrap;gap:12px;margin-top:22px}
+    .hero-copy{position:relative}
+    .hero-slide{display:none}
+    .hero-slide.is-active{display:block}
+    .hero-visual{position:relative;width:min(45vw,490px);aspect-ratio:1/1;margin-left:auto}
+    .hero-visual .ring{
+      position:absolute;inset:0;border-radius:50%;
+      background:radial-gradient(closest-side,#DDE9F0 0 73%,transparent 73%),
+                 conic-gradient(from 0deg,#f1f5f9,#DDE9F0);
+      z-index:0;opacity:.9;filter:drop-shadow(0 30px 60px rgba(2,6,23,.07));
+    }
+    .hero-visual .photo{position:absolute;inset:12%;border-radius:50%;overflow:hidden;box-shadow:var(--shadow);z-index:1}
+    .hero-visual .photo img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity .6s ease}
+    .hero-visual .photo img.is-active{opacity:1}
+    .hero-visual .badge{position:absolute;right:8%;bottom:10%;z-index:2;background:#fff;border:1px solid var(--line);border-radius:12px;padding:10px 14px;box-shadow:var(--shadow);display:flex;align-items:center;gap:8px;font-weight:700;color:var(--accent)}
+    .hero-mobile-visual{display:none;width:min(320px,80vw);aspect-ratio:1/1;border-radius:50%;overflow:hidden;margin:16px auto 0;box-shadow:var(--shadow)}
+    .hero-mobile-visual img{width:100%;height:100%;object-fit:cover}
+    .accent{color:var(--accent)}
+
+    section{padding-block:clamp(40px,5vw,70px)}
+    .section-beige{background:var(--beige);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+    .section-title{text-align:center;margin-bottom:8px;font-size:clamp(1.2rem,2.2vw,1.8rem)}
+    .lead{color:var(--muted);max-width:70ch;margin:0 auto 28px;text-align:center}
+    .card{background:#fafafa;border:1px solid var(--line);border-radius:var(--radius);padding:20px}
+
+    /* Legal layout */
+    .legal-hero .hero-visual .badge{font-size:.85rem;letter-spacing:.03em;text-transform:uppercase}
+    .legal-overview .container{display:grid;gap:22px;justify-items:flex-start;padding-block:clamp(32px,4.8vw,56px)}
+    .legal-intro{background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);padding:clamp(24px,4vw,36px);box-shadow:var(--shadow);max-width:min(620px,100%)}
+    .legal-intro h2{margin:0 0 .6rem;font-size:clamp(1.5rem,2.6vw,2rem)}
+    .legal-intro p{margin:0;color:var(--muted);font-size:1.02rem}
+    .legal-quicklinks{display:flex;gap:12px;flex-wrap:wrap}
+    .legal-quicklinks .pill{font-size:.72rem;letter-spacing:.14em}
+
+    .legal-section{padding-block:clamp(44px,6vw,80px)}
+    .legal-container{max-width:860px;margin:0 auto;padding-inline:var(--pad)}
+    .legal-card{background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);padding:clamp(26px,4.2vw,44px);box-shadow:var(--shadow)}
+    .legal-card h2{margin:0 0 .6rem;font-size:clamp(1.5rem,2.6vw,2rem)}
+    .legal-card h3{margin:1.9rem 0 .7rem;font-size:1.12rem;color:var(--accent)}
+    .legal-card h3:first-of-type{margin-top:1.4rem}
+    .legal-meta{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:.95rem;margin-bottom:1.4rem}
+    .legal-card ul{list-style:disc}
+    .legal-card li{color:var(--ink);line-height:1.6}
+    .legal-card li:last-child{margin-bottom:0}
+    .legal-note{color:var(--muted);margin-top:1.6rem;font-size:.96rem}
+
+    .legal-contact .legal-container{padding-block:0}
+    .legal-contact-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:22px}
+    .legal-contact .card{background:#fff;border-radius:var(--radius-lg);padding:clamp(24px,4vw,32px);box-shadow:var(--shadow);border:1px solid var(--line)}
+    .legal-contact .card h3{margin:0 0 .6rem;font-size:1.18rem;color:var(--accent)}
+    .legal-contact .card p{margin:0 0 .8rem}
+    .legal-contact .card p:last-child{margin-bottom:0}
+
+    footer{background:#0b1220;color:#cbd5e1;padding-block:44px 28px;margin-top:60px}
+    .footer-inner{display:grid;grid-template-columns:1.2fr .8fr;gap:28px;align-items:center}
+    .newsletter{display:flex;gap:10px}
+    .newsletter input{flex:1;padding:12px 14px;border-radius:999px;border:1px solid #334155;background:#0f172a;color:#e2e8f0}
+    .newsletter button{border:none;background:var(--accent);color:#fff;border-radius:999px;padding:12px 18px;font-weight:800}
+    .mini{border-top:1px solid #162036;margin-top:26px;padding-top:16px;text-align:center;color:#94a3b8}
+    footer a{color:#cbd5e1}
+
+    /* Cookie consent */
+    .cookie-banner{position:fixed;bottom:24px;right:24px;width:min(440px,calc(100% - 48px));background:#fff;border:1px solid var(--line);border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:18px 20px;display:grid;gap:12px;z-index:60}
+    .cookie-banner[hidden]{display:none !important}
+    .cookie-banner strong{display:block;font-size:1rem;margin-bottom:4px;color:var(--ink)}
+    .cookie-banner p{margin:0;color:var(--muted);font-size:.92rem}
+    .cookie-banner-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .cookie-btn{font-family:inherit;font-size:.92rem;font-weight:600;border-radius:999px;border:1px solid transparent;padding:.65rem 1.2rem;cursor:pointer;transition:background .2s ease,color .2s ease,border-color .2s ease;display:inline-flex;align-items:center;justify-content:center;gap:.25rem;min-height:44px}
+    .cookie-btn-primary{background:var(--accent);color:#fff}
+    .cookie-btn-primary:hover{filter:brightness(.93)}
+    .cookie-btn-secondary{background:#fff;border-color:var(--line);color:var(--accent)}
+    .cookie-btn-secondary:hover{border-color:#cbd5e1;background:#f8fafc}
+    .cookie-btn-link{background:transparent;color:var(--accent);padding:.55rem .75rem;border:none;margin-right:auto;text-decoration:underline;text-underline-offset:3px}
+    .cookie-btn:focus-visible{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-btn-link:hover{color:var(--accent-dark);background:rgba(10,33,46,.06)}
+
+    .cookie-modal{position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:24px}
+    .cookie-modal[hidden]{display:none !important}
+    .cookie-modal-backdrop{position:absolute;inset:0;background:rgba(15,23,42,.45)}
+    .cookie-modal-content{position:relative;z-index:1;width:min(520px,100%);background:#fff;border-radius:var(--radius-lg);box-shadow:var(--shadow);padding:clamp(24px,4vw,32px);display:grid;gap:18px}
+    .cookie-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+    .cookie-modal-header h2{margin:0;font-size:1.22rem}
+    .cookie-modal-intro{margin:0;color:var(--muted);font-size:.95rem}
+    .cookie-close{border:none;background:transparent;color:var(--muted);font-size:1.6rem;line-height:1;padding:4px;border-radius:8px;cursor:pointer}
+    .cookie-close:hover{color:var(--accent);background:rgba(15,23,42,.08)}
+    .cookie-options{display:grid;gap:10px}
+    .cookie-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 0;border-top:1px solid var(--line);cursor:pointer}
+    .cookie-row:first-of-type{border-top:none;padding-top:4px}
+    .cookie-row-text{max-width:360px;display:block}
+    .cookie-row-title{display:block;font-weight:600;color:var(--ink)}
+    .cookie-row-desc{display:block;font-size:.85rem;color:var(--muted);margin-top:4px}
+    .cookie-row-disabled{cursor:default}
+    .cookie-switch{position:relative;width:48px;height:26px;flex-shrink:0}
+    .cookie-switch input{position:absolute;inset:0;margin:0;opacity:0;cursor:pointer}
+    .cookie-switch span{position:absolute;inset:0;background:#d7dce3;border-radius:999px;transition:background .2s ease}
+    .cookie-switch span::after{content:"";position:absolute;width:20px;height:20px;border-radius:50%;background:#fff;top:3px;left:3px;box-shadow:0 2px 6px rgba(15,23,42,.2);transition:transform .2s ease}
+    .cookie-switch input:checked + span{background:var(--accent)}
+    .cookie-switch input:checked + span::after{transform:translateX(20px)}
+    .cookie-switch input:disabled + span{background:#94a3b8;cursor:not-allowed;opacity:.65}
+    .cookie-switch input:focus-visible + span{outline:3px solid rgba(10,33,46,.35);outline-offset:2px}
+    .cookie-modal-actions{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+    .cookie-modal-actions .cookie-btn{min-width:150px}
+    body.cookie-modal-open{overflow:hidden}
+
+    @media (max-width:600px){
+      .cookie-banner{left:16px;right:16px;bottom:16px;width:auto;padding:16px 18px}
+      .cookie-banner-actions{flex-direction:column;align-items:stretch}
+      .cookie-btn{width:100%}
+      .cookie-btn-link{margin-right:0;text-align:center}
+      .cookie-modal{padding:12px}
+      .cookie-modal-content{width:100%}
+      .cookie-row{flex-direction:column;align-items:flex-start}
+      .cookie-modal-actions{flex-direction:column;align-items:stretch}
+      .cookie-modal-actions .cookie-btn{width:100%}
+    }
+
+    @media (max-width:980px){
+      .menu-toggle{display:inline-flex}
+      .hero .inner{grid-template-columns:1fr;text-align:center}
+      .hero .hero-copy{max-width:560px;margin:0 auto}
+      .hero p.sub{margin-inline:auto}
+      .hero-visual{margin:0 auto;overflow:hidden}
+      .hero-visual .ring{right:-40vw;top:-28vw}
+      .hero-visual .photo{margin-inline:auto}
+      .footer-inner{grid-template-columns:1fr}
+      .menu-panel{position:absolute;top:100%;left:0;right:0;background:#fff;display:grid;gap:0;border-bottom:1px solid var(--line);box-shadow:0 20px 40px rgba(15,23,42,.1);border-radius:0 0 var(--radius) var(--radius);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .25s ease,opacity .25s ease;margin-left:0;max-height:calc(100vh - 66px);overflow:auto}
+      .nav.is-open .menu-panel{transform:translateY(0);opacity:1;pointer-events:auto}
+      .menu{flex-direction:column;align-items:flex-start;gap:0;padding-block:12px}
+      .menu a{width:100%;padding:12px var(--pad);border-top:1px solid var(--line);font-size:1rem}
+      .menu a:first-child{border-top:none}
+      .nav-cta{display:grid;gap:10px;padding:10px var(--pad) 16px;border-top:1px solid var(--line);background:#fff}
+      .nav-cta .btn{width:100%;justify-content:center}
+    }
+
+    @media (max-width:640px){
+      .hero .hero-slide{text-align:center}
+      .hero .hero-slide > *{margin-left:auto;margin-right:auto}
+      .cta-row{flex-direction:column}
+      .cta-row .btn{width:100%;justify-content:center}
+      .hero-visual{display:none}
+      .hero-mobile-visual{display:block}
+      .hero-mobile-visual img{object-position:center}
+      .legal-overview .container{justify-items:center;text-align:center}
+      .legal-intro{text-align:center}
+      .legal-quicklinks{justify-content:center}
+      .legal-card{padding:clamp(22px,5vw,34px);text-align:left}
+      .legal-contact-grid{grid-template-columns:1fr}
+      .legal-contact .card{text-align:left}
+      .newsletter{justify-content:center}
+    }
+  </style>
+</head>
+<body>
+  <!-- Navigation -->
+  <nav class="nav" aria-label="Primary navigation">
+    <div class="container inner">
+      <a class="logo" href="http://www.kovacictalent.com"><img src="https://kovacictalent.com/wp-content/uploads/2025/08/Logo_Kovacic.png" alt="Kovacic Talent logo" class="logo-img"><span> </span></a>
+      <button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span class="menu-label">Menú</span>
+      </button>
+      <div class="menu-panel" id="primary-menu">
+        <div class="menu">
+          <a href="http://www.kovacictalent.com/#sectors">Sectores</a>
+          <a href="http://www.kovacictalent.com/#About">Sobre nosotros</a>
+          <a href="http://www.kovacictalent.com/#Values">Nuestros valores</a>
+          <a href="http://www.kovacictalent.com/#process">Cómo trabajamos</a>
+          <a href="http://www.kovacictalent.com/#processes">Procesos</a>
+          <a href="http://www.kovacictalent.com/#contact">Contacto</a>
+        </div>
+        <div class="nav-cta">
+          <a class="btn btn-ghost" href="https://kovacictalent.com/mejoracv">Enviar CV</a>
+          <a class="btn btn-primary" href="https://kovacictalent.com/#contact">Solicitar una llamada</a>
+          <a class="nav-linkedin" href="https://www.linkedin.com/company/kovacic-executive-talent/" target="_blank" rel="noopener noreferrer" aria-label="Kovacic Talent on LinkedIn (opens in a new tab)">
+            <svg viewbox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003zM6.615 20.452H3.558V9h3.057v11.452zM5.087 7.633a1.773 1.773 0 110-3.546 1.773 1.773 0 010 3.546zm15.36 12.819h-3.054v-5.569c0-1.329-.026-3.036-1.851-3.036-1.851 0-2.136 1.446-2.136 2.94v5.665H10.35V9h2.93v1.561h.041c.408-.77 1.405-1.584 2.894-1.584 3.094 0 3.663 2.039 3.663 4.689v6.786z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- HERO -->
+  <header class="hero legal-hero" id="top">
+    <div class="container inner">
+      <div class="hero-copy">
+        <div class="hero-slide is-active">
+          <span class="pill">Centro legal</span>
+          <h1>Política de privacidad y términos</h1>
+          <div class="hero-mobile-visual">
+            <img src="https://images.unsplash.com/photo-1521790797524-b2497295b8a0?q=80&w=1200&auto=format&fit=crop" alt="Professional reviewing legal documents">
+          </div>
+          <p class="sub">Nuestro compromiso con la privacidad, la transparencia y el uso responsable de este sitio web y nuestros servicios.</p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="#privacy">Leer política de privacidad</a>
+            <a class="btn btn-ghost" href="#terms">Revisar términos</a>
+          </div>
+        </div>
+      </div>
+      <div class="hero-visual">
+        <div class="ring" aria-hidden="true"></div>
+        <div class="photo">
+          <img class="is-active" src="https://images.unsplash.com/photo-1521790797524-b2497295b8a0?q=80&w=1200&auto=format&fit=crop" alt="Professional reviewing legal documents">
+        </div>
+        <div class="badge">Actualizado en enero de 2025</div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="legal-overview section-beige" aria-labelledby="legal-overview-title">
+      <div class="container">
+        <div class="legal-intro">
+          <h2 id="legal-overview-title">Cómo protegemos tu información</h2>
+          <p>Combinamos la búsqueda ejecutiva boutique con un profundo respeto por la privacidad de los datos. Conoce cómo recopilamos, usamos y protegemos la información, además de los términos que rigen el uso de nuestros servicios.</p>
+        </div>
+        <nav class="legal-quicklinks" aria-label="Legal quick links">
+          <a class="pill" href="#privacy">Política de privacidad</a>
+          <a class="pill" href="#terms">Términos y condiciones</a>
+          <a class="pill" href="#contact">Contacto</a>
+        </nav>
+      </div>
+    </section>
+
+    <section id="privacy" class="legal-section" aria-labelledby="privacy-title">
+      <div class="container legal-container">
+        <article class="legal-card">
+          <header>
+            <h2 id="privacy-title">Política de privacidad</h2>
+            <div class="legal-meta">Última actualización: enero de 2025</div>
+          </header>
+          <p>En <strong>Kovacic Executive Talent Research</strong> (“nosotros”, “nuestro”), nos comprometemos a proteger tu privacidad y garantizar el tratamiento lícito y transparente de los datos personales en cumplimiento del <strong>Reglamento General de Protección de Datos (UE) 2016/679 (GDPR)</strong> y la legislación nacional aplicable.</p>
+
+          <h3>1. Datos que recopilamos</h3>
+          <ul>
+            <li><strong>Datos de identificación y contacto</strong> (nombre, correo electrónico, número de teléfono, dirección).</li>
+            <li><strong>Información profesional</strong> (CV, historial profesional, competencias, formación, perfiles de LinkedIn).</li>
+            <li><strong>Datos de evaluación</strong> (notas de entrevistas, referencias, evaluaciones).</li>
+            <li><strong>Datos de clientes</strong> (detalles de la organización, personas de contacto, necesidades de reclutamiento).</li>
+            <li><strong>Datos técnicos</strong> (cookies, dirección IP, información del dispositivo/navegador).</li>
+          </ul>
+
+          <h3>2. Cómo utilizamos tus datos</h3>
+          <ul>
+            <li>Prestar servicios de búsqueda y reclutamiento ejecutivo.</li>
+            <li>Evaluar y presentar candidatos a los clientes (con consentimiento previo).</li>
+            <li>Comunicarnos sobre oportunidades, proyectos o colaboraciones.</li>
+            <li>Mantener relaciones comerciales con clientes y candidatos.</li>
+            <li>Cumplir obligaciones legales y regulatorias.</li>
+          </ul>
+
+          <h3>3. Base legal para el tratamiento</h3>
+          <ul>
+            <li><strong>Consentimiento</strong> (Art. 6.1.a GDPR): cuando compartes tu CV o información profesional.</li>
+            <li><strong>Contrato</strong> (Art. 6.1.b): para cumplir obligaciones derivadas de acuerdos de servicios.</li>
+            <li><strong>Intereses legítimos</strong> (Art. 6.1.f): operar y mejorar nuestros servicios respetando tus derechos.</li>
+            <li><strong>Obligaciones legales</strong> (Art. 6.1.c): obligaciones contables, fiscales o laborales.</li>
+          </ul>
+
+          <h3>4. Compartición de datos</h3>
+          <ul>
+            <li>Los perfiles de candidatos pueden compartirse con <strong>clientes</strong> como parte de los procesos de selección, con consentimiento previo explícito.</li>
+            <li>No <strong>vendemos</strong> ni intercambiamos datos personales.</li>
+            <li>Los proveedores de servicios (hosting, CRM) pueden tratar datos bajo contratos escritos con garantías adecuadas.</li>
+            <li>Las transferencias fuera del EEE se realizan únicamente con protecciones adecuadas (p. ej., Cláusulas Contractuales Tipo).</li>
+          </ul>
+
+          <h3>5. Conservación de datos</h3>
+          <ul>
+            <li>Datos de candidatos: se conservan hasta <strong>5 años</strong> salvo que solicites su eliminación antes.</li>
+            <li>Datos de clientes/negocio: se conservan durante la relación y según la normativa aplicable.</li>
+            <li>CV y materiales de candidatura: pueden conservarse para futuras oportunidades con tu consentimiento.</li>
+          </ul>
+
+          <h3>6. Tus derechos</h3>
+          <p>En virtud del GDPR puedes solicitar acceso, rectificación, supresión, limitación, oposición y portabilidad. También puedes retirar tu consentimiento en cualquier momento y presentar una reclamación ante tu autoridad de control.</p>
+          <p><strong>Contacto para solicitudes:</strong> <a href="mailto:info@kovacictalent.com">info@kovacictalent.com</a></p>
+
+          <h3>7. Medidas de seguridad</h3>
+          <p>Aplicamos medidas técnicas y organizativas (cifrado, controles de acceso, hosting seguro) para proteger los datos personales.</p>
+
+          <h3>8. Cookies y analítica</h3>
+          <p>Nuestro sitio utiliza cookies para mejorar tu experiencia y puede incluir herramientas de analítica (p. ej., Google Analytics). Puedes gestionarlas desde la configuración de tu navegador.</p>
+
+          <h3>9. Cambios en esta política</h3>
+          <p>Podemos actualizar esta política de privacidad periódicamente. Publicaremos los cambios junto con la nueva fecha de “Última actualización”.</p>
+        </article>
+      </div>
+    </section>
+    <section id="terms" class="legal-section section-beige" aria-labelledby="terms-title">
+      <div class="container legal-container">
+        <article class="legal-card">
+          <header>
+            <h2 id="terms-title">Términos y condiciones</h2>
+            <div class="legal-meta">Última actualización: enero de 2025</div>
+          </header>
+          <p>Bienvenido a <strong>Kovacic Executive Talent Research</strong>. Al acceder o utilizar nuestro sitio y servicios aceptas estos Términos y Condiciones.</p>
+
+          <h3>1. Alcance de los servicios</h3>
+          <p>Ofrecemos <strong>servicios de búsqueda ejecutiva, reclutamiento e inteligencia de mercado</strong> . La información del sitio es de carácter general y puede actualizarse sin previo aviso.</p>
+
+          <h3>2. Uso del sitio web</h3>
+          <ul>
+            <li>Utiliza el sitio solo con fines legítimos.</li>
+            <li>No intentes obtener acceso no autorizado a sistemas, datos o cuentas.</li>
+            <li>Podemos restringir o cancelar el acceso en caso de uso indebido.</li>
+          </ul>
+
+          <h3>3. Propiedad intelectual</h3>
+          <p>Todo el contenido del sitio (texto, gráficos, diseño, logotipos, materiales) es de nuestra propiedad o de nuestros licenciantes y no puede reproducirse sin autorización por escrito.</p>
+
+          <h3>4. Confidencialidad y datos de candidatos</h3>
+          <p>Las candidaturas (por ejemplo, CV) se tratan de forma confidencial. Los clientes se comprometen a mantener la misma confidencialidad sobre la información recibida.</p>
+
+          <h3>5. Limitación de responsabilidad</h3>
+          <p>Aunque procuramos la exactitud, no garantizamos que el contenido del sitio esté libre de errores ni sea adecuado para un fin específico. En la medida permitida por la ley, no seremos responsables de pérdidas o daños derivados del uso del sitio, los servicios o enlaces externos.</p>
+
+          <h3>6. Enlaces externos</h3>
+          <p>Los enlaces a sitios de terceros se proporcionan por conveniencia. No controlamos ni respaldamos su contenido y rechazamos responsabilidad por sus políticas y prácticas.</p>
+
+          <h3>7. Ley aplicable y jurisdicción</h3>
+          <p>Estos Términos se rigen por la legislación de la UE y las leyes de España. Cualquier disputa se somete a la jurisdicción exclusiva de los tribunales de Barcelona, España.</p>
+
+          <h3>8. Cambios en los términos</h3>
+          <p>Podemos actualizar estos Términos periódicamente. El uso continuado del sitio implica la aceptación de la versión actualizada.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="contact" class="legal-section legal-contact" aria-labelledby="contact-title">
+      <div class="container legal-container">
+        <div class="legal-contact-grid">
+          <div class="card">
+            <h3 id="contact-title">Solicitudes y consultas de datos</h3>
+            <p>Si deseas ejercer tus derechos o tienes preguntas sobre esta política, contáctanos directamente.</p>
+            <p><strong>Correo electrónico:</strong> <a href="mailto:info@kovacictalent.com">info@kovacictalent.com</a></p>
+            <p class="legal-note">Nuestro objetivo es responder a todas las consultas de privacidad en un plazo de <strong>48 horas</strong>.</p>
+          </div>
+          <div class="card">
+            <h3>Cómo gestionamos tu solicitud</h3>
+            <p>Al contactarnos, verificaremos tu identidad, registraremos la solicitud y responderemos con las acciones realizadas.</p>
+            <ul>
+              <li>Confirmación de recepción en un plazo de dos días laborables.</li>
+              <li>Respuesta o actualización sustancial dentro de un mes.</li>
+              <li>Transferencia segura de cualquier dato personal solicitado.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <div>
+        <p style="color:#94a3b8;max-width:58ch">Búsqueda ejecutiva y selección de especialistas senior en Tecnología y Energía Renovable. Servicio boutique, alcance global.</p>
+      </div>
+      <div>
+        <form class="newsletter" onsubmit="event.preventDefault(); alert('Subscribed!');">
+          <input type="email" required placeholder="Subscribe with your email">
+          <button type="submit">Suscribirme</button>
+        </form>
+      </div>
+    </div>
+    <div class="container mini">
+      © <span id="y"></span> Kovacic Talent. Todos los derechos reservados · <a href="https://kovacictalent.com/privacy-terms/#privacy">Privacidad</a> · <a href="https://kovacictalent.com/privacy-terms/#terms">Términos</a>
+    </div>
+  </footer>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-desc">
+    <div class="cookie-banner-text">
+      <strong id="cookie-banner-title">Tu privacidad es importante</strong>
+      <p id="cookie-banner-desc">Usamos cookies para mantener funciones esenciales, analizar el rendimiento y apoyar el marketing. Actualiza tus preferencias cuando quieras.</p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-link" data-cookie-open>Preferencias</button>
+      <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-reject>Rechazar</button>
+      <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-accept>Aceptar</button>
+    </div>
+  </div>
+
+  <div class="cookie-modal" data-cookie-modal hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title">
+    <div class="cookie-modal-backdrop" data-cookie-close></div>
+    <div class="cookie-modal-content" role="document">
+      <header class="cookie-modal-header">
+        <h2 id="cookie-modal-title">Preferencias de cookies</h2>
+        <button type="button" class="cookie-close" data-cookie-close aria-label="Close cookie preferences"><span aria-hidden="true">×</span></button>
+      </header>
+      <p class="cookie-modal-intro">Decide qué cookies opcionales podemos usar. Las cookies esenciales permanecen activas para las funciones fundamentales del sitio.</p>
+      <div class="cookie-options">
+        <label class="cookie-row cookie-row-disabled">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Esenciales</span>
+            <span class="cookie-row-desc">Necesarias para funciones básicas como la navegación, la seguridad y recordar tus preferencias.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="essential" checked disabled>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Analítica</span>
+            <span class="cookie-row-desc">Nos ayuda a entender cómo se utiliza esta página para mejorar la experiencia.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="analytics" data-focus-first>
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="cookie-row">
+          <span class="cookie-row-text">
+            <span class="cookie-row-title">Marketing</span>
+            <span class="cookie-row-desc">Permite personalizar el contenido y medir campañas en nuestros canales.</span>
+          </span>
+          <span class="cookie-switch">
+            <input type="checkbox" data-cookie-toggle="marketing">
+            <span aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+      <div class="cookie-modal-actions">
+        <button type="button" class="cookie-btn cookie-btn-secondary" data-cookie-close>Cancelar</button>
+        <button type="button" class="cookie-btn cookie-btn-primary" data-cookie-save>Guardar preferencias</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('y').textContent = new Date().getFullYear();
+
+    (function(){
+      const nav = document.querySelector('.nav');
+      const toggle = document.querySelector('.menu-toggle');
+      const panel = document.getElementById('primary-menu');
+      if(!nav || !toggle || !panel) return;
+      const links = panel.querySelectorAll('a');
+
+      const closeMenu = () => {
+        nav.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded','false');
+        document.body.classList.remove('nav-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+
+      links.forEach(link => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if(window.innerWidth > 980){
+          closeMenu();
+        }
+      });
+    })();
+  </script>
+  <script>
+    (function(){
+      const STORAGE_KEY = 'kt_cookie_preferences';
+      const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
+      const defaults = { essential:true, analytics:false, marketing:false };
+      const banner = document.querySelector('[data-cookie-banner]');
+      const modal = document.querySelector('[data-cookie-modal]');
+      if(!banner || !modal) return;
+
+      const storage = (() => {
+        try{
+          const key = '__cookie_test__';
+          localStorage.setItem(key,'1');
+          localStorage.removeItem(key);
+          return localStorage;
+        }catch(err){
+          return null;
+        }
+      })();
+
+      const readStorage = () => {
+        if(!storage) return null;
+        try{
+          const raw = storage.getItem(STORAGE_KEY);
+          return raw ? JSON.parse(raw) : null;
+        }catch(err){
+          return null;
+        }
+      };
+
+      const persistStorage = prefs => {
+        if(!storage || !prefs || typeof prefs !== 'object') return;
+        try{
+          storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readCookie = () => {
+        if(!document.cookie) return null;
+        const prefix = `${STORAGE_KEY}=`;
+        const cookies = document.cookie.split(';');
+        for(const entry of cookies){
+          const trimmed = entry.trim();
+          if(trimmed.startsWith(prefix)){
+            const value = trimmed.slice(prefix.length);
+            if(!value) return null;
+            try{
+              return JSON.parse(decodeURIComponent(value));
+            }catch(err){
+              return null;
+            }
+          }
+        }
+        return null;
+      };
+
+      const persistCookie = prefs => {
+        if(!prefs || typeof prefs !== 'object') return;
+        try{
+          const value = encodeURIComponent(JSON.stringify(prefs));
+          document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+        }catch(err){
+          /* no-op */
+        }
+      };
+
+      const readStored = () => readStorage() || readCookie();
+
+      const persist = prefs => {
+        persistStorage(prefs);
+        persistCookie(prefs);
+      };
+
+      const mergePrefs = prefs => Object.assign({}, defaults, (prefs && typeof prefs === 'object') ? prefs : {});
+
+      const runScripts = prefs => {
+        const selector = 'script[type="text/plain"][data-cookiecategory]';
+        document.querySelectorAll(selector).forEach(node => {
+          const categories = node.dataset.cookiecategory.split(',').map(cat => cat.trim().toLowerCase()).filter(Boolean);
+          if(!categories.length) return;
+          const allowed = categories.some(cat => prefs[cat]);
+          if(!allowed) return;
+          const script = document.createElement('script');
+          Array.from(node.attributes).forEach(attr => {
+            if(attr.name === 'type' || attr.name === 'data-cookiecategory') return;
+            script.setAttribute(attr.name, attr.value);
+          });
+          script.textContent = node.textContent;
+          node.parentNode.replaceChild(script, node);
+        });
+      };
+
+      const toggleInputs = modal.querySelectorAll('input[data-cookie-toggle]');
+      const updateToggles = prefs => {
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat) return;
+          if(cat === 'essential'){
+            input.checked = true;
+            return;
+          }
+          input.checked = !!prefs[cat];
+        });
+      };
+
+      const hideBanner = () => {
+        banner.hidden = true;
+        banner.setAttribute('aria-hidden','true');
+      };
+
+      const showBanner = () => {
+        banner.hidden = false;
+        banner.removeAttribute('aria-hidden');
+      };
+
+      let lastFocus = null;
+      const hideModal = () => {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden','true');
+        document.body.classList.remove('cookie-modal-open');
+        if(lastFocus){
+          lastFocus.focus();
+          lastFocus = null;
+        }
+      };
+
+      const focusModal = () => {
+        const target = modal.querySelector('[data-focus-first]') || modal.querySelector('[data-cookie-close]') || modal;
+        setTimeout(() => target.focus(), 0);
+      };
+
+      const showModal = () => {
+        modal.hidden = false;
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('cookie-modal-open');
+        focusModal();
+      };
+
+      const applyPrefs = prefs => {
+        const merged = mergePrefs(prefs);
+        persist(merged);
+        updateToggles(merged);
+        runScripts(merged);
+        hideBanner();
+        hideModal();
+      };
+
+      const acceptBtn = banner.querySelector('[data-cookie-accept]');
+      const rejectBtn = banner.querySelector('[data-cookie-reject]');
+      const openBtns = document.querySelectorAll('[data-cookie-open]');
+      const closeBtns = document.querySelectorAll('[data-cookie-close]');
+      const saveBtn = modal.querySelector('[data-cookie-save]');
+
+      acceptBtn?.addEventListener('click', () => applyPrefs({ analytics:true, marketing:true }));
+      rejectBtn?.addEventListener('click', () => applyPrefs({ analytics:false, marketing:false }));
+
+      openBtns.forEach(btn => btn.addEventListener('click', () => {
+        lastFocus = document.activeElement;
+        updateToggles(mergePrefs(readStored()));
+        showModal();
+      }));
+
+      closeBtns.forEach(btn => btn.addEventListener('click', () => {
+        hideModal();
+      }));
+
+      saveBtn?.addEventListener('click', () => {
+        const prefs = mergePrefs(readStored());
+        toggleInputs.forEach(input => {
+          const cat = input.dataset.cookieToggle;
+          if(!cat || cat === 'essential') return;
+          prefs[cat] = input.checked;
+        });
+        applyPrefs(prefs);
+      });
+
+      document.addEventListener('keydown', event => {
+        if(event.key === 'Escape' && !modal.hidden){
+          hideModal();
+        }
+      });
+
+      const stored = readStored();
+      const initial = mergePrefs(stored);
+      if(stored){
+        persist(initial);
+        hideBanner();
+      } else {
+        showBanner();
+      }
+      updateToggles(initial);
+      runScripts(initial);
+    })();
+  </script>
+</body>
+</html>

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -65,6 +65,10 @@
     padding: 0;
 }
 
+.nav .kls-switcher__item {
+    flex: 0 0 auto;
+}
+
 .kls-switcher__item > .kls-switcher {
     flex-shrink: 0;
 }

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -67,3 +67,17 @@
     flex-shrink: 0;
 }
 
+.kls-switcher__item--logo {
+    margin-left: clamp(0.5rem, 1vw + 0.25rem, 1.25rem);
+    flex-shrink: 0;
+}
+
+.nav .kls-switcher__item--logo {
+    display: inline-flex;
+    align-items: center;
+}
+
+.nav .kls-switcher--logo {
+    margin: 0;
+}
+

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -88,18 +88,26 @@
 }
 
 .site-header .custom-logo-link,
-.site-header .custom-logo-link img,
 .site-header .wp-block-site-logo,
-.site-header .wp-block-site-logo img,
 .site-header .site-logo,
-.site-header .site-logo img,
 .nav .custom-logo-link,
-.nav .custom-logo-link img,
 .nav .wp-block-site-logo,
+.nav .site-logo {
+    flex: 0 0 auto !important;
+    width: auto !important;
+    min-width: var(--kls-logo-min-width, auto);
+}
+
+.site-header .custom-logo-link img,
+.site-header .wp-block-site-logo img,
+.site-header .site-logo img,
+.nav .custom-logo-link img,
 .nav .wp-block-site-logo img,
-.nav .site-logo,
 .nav .site-logo img {
-    flex-shrink: 0;
-    max-width: none;
+    flex: 0 0 auto !important;
+    width: auto !important;
+    height: auto !important;
+    min-width: var(--kls-logo-min-width, auto);
+    max-width: none !important;
 }
 

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -1,0 +1,45 @@
+.kls-switcher {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: inherit;
+}
+
+.kls-switcher__button {
+    appearance: none;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    background: transparent;
+    color: currentColor;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.kls-switcher__button:hover,
+.kls-switcher__button:focus {
+    outline: none;
+    border-color: currentColor;
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+.kls-switcher__button--active {
+    background-color: currentColor;
+    color: #111827;
+    border-color: currentColor;
+}
+
+.kls-switcher__item {
+    display: flex;
+    align-items: center;
+}
+
+.kls-switcher-portal {
+    display: none;
+}
+
+.kls-switcher-portal[hidden] {
+    display: none !important;
+}

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -83,3 +83,19 @@
     margin: 0;
 }
 
+.site-header .custom-logo-link,
+.site-header .custom-logo-link img,
+.site-header .wp-block-site-logo,
+.site-header .wp-block-site-logo img,
+.site-header .site-logo,
+.site-header .site-logo img,
+.nav .custom-logo-link,
+.nav .custom-logo-link img,
+.nav .wp-block-site-logo,
+.nav .wp-block-site-logo img,
+.nav .site-logo,
+.nav .site-logo img {
+    flex-shrink: 0;
+    max-width: none;
+}
+

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -1,39 +1,57 @@
 .kls-switcher {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.25rem;
     font-family: inherit;
+    border-radius: 999px;
+    padding: 0.125rem;
+    background: rgba(255, 255, 255, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+    white-space: nowrap;
+}
+
+.kls-switcher--nav {
+    margin: 0;
 }
 
 .kls-switcher__button {
     appearance: none;
-    border: 1px solid rgba(255, 255, 255, 0.4);
+    border: 0;
     background: transparent;
-    color: currentColor;
-    padding: 0.35rem 0.75rem;
+    color: #0f172a;
+    padding: 0.35rem 0.9rem;
     border-radius: 999px;
     font-size: 0.875rem;
     line-height: 1.25rem;
+    font-weight: 600;
     cursor: pointer;
-    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .kls-switcher__button:hover,
-.kls-switcher__button:focus {
+.kls-switcher__button:focus-visible {
     outline: none;
-    border-color: currentColor;
-    background-color: rgba(255, 255, 255, 0.15);
+    background-color: rgba(15, 23, 42, 0.1);
 }
 
 .kls-switcher__button--active {
-    background-color: currentColor;
-    color: #111827;
-    border-color: currentColor;
+    background-color: #0f172a;
+    color: #ffffff;
+    box-shadow: 0 4px 14px rgba(15, 23, 42, 0.25);
 }
 
 .kls-switcher__item {
     display: flex;
     align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.kls-switcher__item > .kls-switcher {
+    flex-shrink: 0;
 }
 
 .kls-switcher-portal {

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -48,11 +48,13 @@
 }
 
 .kls-switcher--nav {
-    gap: 0.5rem;
+    gap: 0.35rem;
 }
 
 .kls-switcher--nav .kls-switcher__button {
-    padding-inline: 0.9rem;
+    padding: 0.35rem 0.6rem;
+    font-size: 0.75rem;
+    line-height: 1.1;
 }
 
 .kls-switcher__item {

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -70,8 +70,8 @@
 }
 
 .kls-switcher__item--logo {
-    margin-left: clamp(0.5rem, 1vw + 0.25rem, 1.25rem);
-    flex-shrink: 0;
+    margin-right: clamp(0.5rem, 1vw + 0.25rem, 1.25rem);
+    flex: 0 0 auto;
 }
 
 .nav .kls-switcher__item--logo {

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -1,77 +1,58 @@
 .kls-switcher {
-    position: relative;
     display: inline-flex;
-    align-items: stretch;
-    gap: 0;
+    align-items: center;
+    gap: 0.5rem;
     font-family: inherit;
+    white-space: nowrap;
+}
+
+.kls-switcher:not(.kls-switcher--nav) {
+    padding: 0.5rem;
     border-radius: 999px;
-    padding: 0.25rem;
     background: rgba(248, 250, 252, 0.92);
     border: 1px solid rgba(226, 232, 240, 0.85);
     box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
-    white-space: nowrap;
-    min-width: 8.75rem;
-    backdrop-filter: blur(10px);
-}
-
-.kls-switcher::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.35), rgba(226, 232, 240, 0.1));
-    z-index: 0;
-}
-
-.kls-switcher__indicator {
-    position: absolute;
-    top: 4px;
-    bottom: 4px;
-    left: 4px;
-    width: calc((100% - 8px) / 2);
-    background: #0f172a;
-    border-radius: 999px;
-    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.35);
-    transition: transform 0.25s ease;
-    z-index: 1;
-    pointer-events: none;
-}
-
-.kls-switcher--nav {
-    margin: 0;
+    backdrop-filter: blur(8px);
 }
 
 .kls-switcher__button {
-    position: relative;
-    z-index: 2;
-    flex: 1 1 0;
     appearance: none;
-    border: 0;
+    border: 1px solid #0f172a;
     background: transparent;
     color: #0f172a;
-    padding: 0.45rem 0.9rem;
+    padding: 0.6rem 0.95rem;
     border-radius: 999px;
-    font-size: 0.875rem;
+    font-size: 0.85rem;
     line-height: 1.25rem;
     font-weight: 600;
     letter-spacing: 0.01em;
     cursor: pointer;
-    transition: color 0.25s ease;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .kls-switcher__button:hover,
 .kls-switcher__button:focus-visible {
-    outline: none;
+    background-color: rgba(15, 23, 42, 0.1);
     color: #020617;
+    outline: none;
 }
 
 .kls-switcher__button:focus-visible {
-    box-shadow: inset 0 0 0 2px rgba(15, 23, 42, 0.15);
-    border-radius: inherit;
+    box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.2);
 }
 
 .kls-switcher__button--active {
+    background-color: #0f172a;
     color: #ffffff;
+    border-color: #0f172a;
+}
+
+.kls-switcher--nav {
+    gap: 0.5rem;
+}
+
+.kls-switcher--nav .kls-switcher__button {
+    padding-inline: 0.9rem;
 }
 
 .kls-switcher__item {
@@ -84,10 +65,5 @@
 
 .kls-switcher__item > .kls-switcher {
     flex-shrink: 0;
-}
-
-.kls-switcher--nav .kls-switcher__button {
-    font-size: 0.8rem;
-    padding-inline: 0.85rem;
 }
 

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -1,15 +1,40 @@
 .kls-switcher {
+    position: relative;
     display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
+    align-items: stretch;
+    gap: 0;
     font-family: inherit;
     border-radius: 999px;
-    padding: 0.125rem;
-    background: rgba(255, 255, 255, 0.35);
-    border: 1px solid rgba(255, 255, 255, 0.5);
-    backdrop-filter: blur(6px);
-    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+    padding: 0.25rem;
+    background: rgba(248, 250, 252, 0.92);
+    border: 1px solid rgba(226, 232, 240, 0.85);
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
     white-space: nowrap;
+    min-width: 8.75rem;
+    backdrop-filter: blur(10px);
+}
+
+.kls-switcher::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.35), rgba(226, 232, 240, 0.1));
+    z-index: 0;
+}
+
+.kls-switcher__indicator {
+    position: absolute;
+    top: 4px;
+    bottom: 4px;
+    left: 4px;
+    width: calc((100% - 8px) / 2);
+    background: #0f172a;
+    border-radius: 999px;
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.35);
+    transition: transform 0.25s ease;
+    z-index: 1;
+    pointer-events: none;
 }
 
 .kls-switcher--nav {
@@ -17,29 +42,36 @@
 }
 
 .kls-switcher__button {
+    position: relative;
+    z-index: 2;
+    flex: 1 1 0;
     appearance: none;
     border: 0;
     background: transparent;
     color: #0f172a;
-    padding: 0.35rem 0.9rem;
+    padding: 0.45rem 0.9rem;
     border-radius: 999px;
     font-size: 0.875rem;
     line-height: 1.25rem;
     font-weight: 600;
+    letter-spacing: 0.01em;
     cursor: pointer;
-    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    transition: color 0.25s ease;
 }
 
 .kls-switcher__button:hover,
 .kls-switcher__button:focus-visible {
     outline: none;
-    background-color: rgba(15, 23, 42, 0.1);
+    color: #020617;
+}
+
+.kls-switcher__button:focus-visible {
+    box-shadow: inset 0 0 0 2px rgba(15, 23, 42, 0.15);
+    border-radius: inherit;
 }
 
 .kls-switcher__button--active {
-    background-color: #0f172a;
     color: #ffffff;
-    box-shadow: 0 4px 14px rgba(15, 23, 42, 0.25);
 }
 
 .kls-switcher__item {
@@ -52,6 +84,11 @@
 
 .kls-switcher__item > .kls-switcher {
     flex-shrink: 0;
+}
+
+.kls-switcher--nav .kls-switcher__button {
+    font-size: 0.8rem;
+    padding-inline: 0.85rem;
 }
 
 .kls-switcher-portal {

--- a/wp-language-switcher/assets/css/translation-switcher.css
+++ b/wp-language-switcher/assets/css/translation-switcher.css
@@ -91,10 +91,3 @@
     padding-inline: 0.85rem;
 }
 
-.kls-switcher-portal {
-    display: none;
-}
-
-.kls-switcher-portal[hidden] {
-    display: none !important;
-}

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -180,8 +180,13 @@
     function injectIntoNavigation() {
         var navigation = document.querySelector('#primary-menu, nav .primary-menu, nav[aria-label*="Primary" i] .menu, nav[aria-label*="Primary" i], .primary-menu');
         if (!navigation) {
+            if (switcherContainer) {
+                switcherContainer.classList.remove('kls-switcher--nav');
+            }
             return;
         }
+
+        switcherContainer.classList.add('kls-switcher--nav');
 
         var linkedInLink = navigation.querySelector('a[href*="linkedin.com" i]');
         var linkedInItem = linkedInLink ? linkedInLink.closest('li') : null;

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -297,7 +297,11 @@
             wrapper.classList.add('kls-switcher__item');
             switcher.classList.add('kls-switcher--nav');
             wrapper.appendChild(switcher);
-            parentList.insertBefore(wrapper, navItem);
+            if (navItem.nextSibling) {
+                parentList.insertBefore(wrapper, navItem.nextSibling);
+            } else {
+                parentList.appendChild(wrapper);
+            }
 
             if (portal) {
                 portal.hidden = true;
@@ -318,7 +322,11 @@
             parent.classList.add('kls-switcher__item');
         }
 
-        parent.insertBefore(switcher, linkedinLink);
+        if (linkedinLink.nextSibling) {
+            parent.insertBefore(switcher, linkedinLink.nextSibling);
+        } else {
+            parent.appendChild(switcher);
+        }
 
         if (portal) {
             portal.hidden = true;

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -288,11 +288,7 @@
             switcher.classList.add('kls-switcher--nav', 'kls-switcher--logo');
             wrapper.appendChild(switcher);
 
-            if (logoElement.nextSibling) {
-                parent.insertBefore(wrapper, logoElement.nextSibling);
-            } else {
-                parent.appendChild(wrapper);
-            }
+            parent.insertBefore(wrapper, logoElement);
 
             if (portal) {
                 portal.hidden = true;

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -122,6 +122,7 @@
     var switcherContainer;
     var englishButton;
     var spanishButton;
+    var switcherIndicator;
     var navigationWrapper = null;
     var navigationInterval = null;
     var navigationObserver = null;
@@ -137,11 +138,17 @@
             spanishButton.classList.add(activeClass);
             englishButton.setAttribute('aria-pressed', 'false');
             spanishButton.setAttribute('aria-pressed', 'true');
+            if (switcherIndicator) {
+                switcherIndicator.style.transform = 'translateX(100%)';
+            }
         } else {
             spanishButton.classList.remove(activeClass);
             englishButton.classList.add(activeClass);
             spanishButton.setAttribute('aria-pressed', 'false');
             englishButton.setAttribute('aria-pressed', 'true');
+            if (switcherIndicator) {
+                switcherIndicator.style.transform = 'translateX(0)';
+            }
         }
     }
 
@@ -150,6 +157,10 @@
         switcherContainer.className = 'kls-switcher';
         switcherContainer.setAttribute('role', 'group');
         switcherContainer.setAttribute('aria-label', 'Language selector');
+
+        switcherIndicator = document.createElement('span');
+        switcherIndicator.className = 'kls-switcher__indicator';
+        switcherContainer.appendChild(switcherIndicator);
 
         englishButton = document.createElement('button');
         englishButton.type = 'button';

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -8,6 +8,7 @@
     var translations = settings.translations || {};
     var normalizedTranslations = {};
     var hasTranslations = false;
+    var STORAGE_KEY = 'klsPreferredLanguage';
 
     function normalize(value) {
         return value.replace(/\s+/g, ' ').trim();
@@ -29,6 +30,27 @@
 
     var language = (settings.defaultLanguage === 'es') ? 'es' : 'en';
     var textNodes = [];
+
+    function getStoredLanguage() {
+        try {
+            return window.localStorage.getItem(STORAGE_KEY);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function persistLanguage(value) {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, value);
+        } catch (error) {
+            /* noop */
+        }
+    }
+
+    var storedLanguage = getStoredLanguage();
+    if (storedLanguage === 'es' || storedLanguage === 'en') {
+        language = storedLanguage;
+    }
 
     function collectTextNodes() {
         var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
@@ -87,6 +109,10 @@
     }
 
     function setLanguage(nextLanguage) {
+        if (nextLanguage !== 'en' && nextLanguage !== 'es') {
+            return;
+        }
+
         if (language === nextLanguage) {
             return;
         }
@@ -117,12 +143,12 @@
         }
 
         updateButtonStates();
+        persistLanguage(language);
     }
 
     var switcherContainer;
     var englishButton;
     var spanishButton;
-    var switcherIndicator;
 
     function updateButtonStates() {
         if (!englishButton || !spanishButton) {
@@ -135,17 +161,11 @@
             spanishButton.classList.add(activeClass);
             englishButton.setAttribute('aria-pressed', 'false');
             spanishButton.setAttribute('aria-pressed', 'true');
-            if (switcherIndicator) {
-                switcherIndicator.style.transform = 'translateX(100%)';
-            }
         } else {
             spanishButton.classList.remove(activeClass);
             englishButton.classList.add(activeClass);
             spanishButton.setAttribute('aria-pressed', 'false');
             englishButton.setAttribute('aria-pressed', 'true');
-            if (switcherIndicator) {
-                switcherIndicator.style.transform = 'translateX(0)';
-            }
         }
     }
 
@@ -163,7 +183,6 @@
             return false;
         }
 
-        switcherIndicator = switcherContainer.querySelector('.kls-switcher__indicator');
         englishButton = switcherContainer.querySelector('[data-language="en"]');
         spanishButton = switcherContainer.querySelector('[data-language="es"]');
 
@@ -192,7 +211,6 @@
             return;
         }
 
-        updateButtonStates();
         updateLanguage();
     }
 

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -276,7 +276,7 @@
     }
 
     function mountSwitcherByLinkedIn(switcher, portal) {
-        var linkedinLink = document.querySelector('a[href*="linkedin.com"]');
+        var linkedinLink = document.querySelector('nav a[href*="linkedin.com"], .menu a[href*="linkedin.com"], a[href*="linkedin.com"]');
         if (!linkedinLink) {
             return false;
         }
@@ -284,24 +284,21 @@
         var originalParent = switcher.parentNode;
         var navItem = linkedinLink.closest('li, .wp-block-navigation-item, .menu-item');
         if (navItem && navItem.parentNode) {
-            var parentList = navItem.parentNode;
             var tagName = navItem.tagName ? navItem.tagName.toLowerCase() : 'div';
             var wrapper = document.createElement(tagName === 'li' ? 'li' : 'div');
 
             if (navItem.classList && navItem.classList.length) {
                 navItem.classList.forEach(function(cls) {
-                    wrapper.classList.add(cls);
+                    if (typeof cls === 'string' && cls.toLowerCase().indexOf('linkedin') === -1) {
+                        wrapper.classList.add(cls);
+                    }
                 });
             }
 
             wrapper.classList.add('kls-switcher__item');
             switcher.classList.add('kls-switcher--nav');
             wrapper.appendChild(switcher);
-            if (navItem.nextSibling) {
-                parentList.insertBefore(wrapper, navItem.nextSibling);
-            } else {
-                parentList.appendChild(wrapper);
-            }
+            navItem.insertAdjacentElement('afterend', wrapper);
 
             if (portal) {
                 portal.hidden = true;
@@ -322,11 +319,7 @@
             parent.classList.add('kls-switcher__item');
         }
 
-        if (linkedinLink.nextSibling) {
-            parent.insertBefore(switcher, linkedinLink.nextSibling);
-        } else {
-            parent.appendChild(switcher);
-        }
+        linkedinLink.insertAdjacentElement('afterend', switcher);
 
         if (portal) {
             portal.hidden = true;

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -262,16 +262,9 @@
         return true;
     }
 
-    function mountSwitcherNearLogo() {
+    function mountSwitcherNearLogo(switcher, portal) {
         if (document.querySelector('.kls-switcher--logo')) {
             return true;
-        }
-
-        var portal = document.getElementById('kls-switcher-root');
-        var switcher = portal ? portal.querySelector('.kls-switcher') : null;
-
-        if (!switcher) {
-            switcher = document.querySelector('.kls-switcher');
         }
 
         if (!switcher) {
@@ -299,7 +292,30 @@
             return true;
         }
 
-        return mountSwitcherByLinkedIn(switcher, portal);
+        return false;
+    }
+
+    function mountPreferredSwitcherLocation(allowFallback) {
+        var portal = document.getElementById('kls-switcher-root');
+        var switcher = portal ? portal.querySelector('.kls-switcher') : null;
+
+        if (!switcher) {
+            switcher = document.querySelector('.kls-switcher');
+        }
+
+        if (!switcher) {
+            return false;
+        }
+
+        if (mountSwitcherByLinkedIn(switcher, portal)) {
+            return true;
+        }
+
+        if (allowFallback && mountSwitcherNearLogo(switcher, portal)) {
+            return true;
+        }
+
+        return false;
     }
 
     function updateButtonStates() {
@@ -322,7 +338,7 @@
     }
 
     function findSwitcherElements(allowFallback) {
-        if (!mountSwitcherNearLogo() && allowFallback) {
+        if (!mountPreferredSwitcherLocation(allowFallback) && allowFallback) {
             var portal = document.getElementById('kls-switcher-root');
             if (portal) {
                 portal.removeAttribute('hidden');
@@ -389,7 +405,7 @@
                 updateLanguage();
             }
 
-            if (document.querySelector('.kls-switcher--logo')) {
+            if (document.querySelector('.kls-switcher--logo, .kls-switcher--nav')) {
                 return;
             }
 

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -122,6 +122,9 @@
     var switcherContainer;
     var englishButton;
     var spanishButton;
+    var navigationWrapper = null;
+    var navigationInterval = null;
+    var navigationObserver = null;
 
     function updateButtonStates() {
         if (!englishButton || !spanishButton) {
@@ -173,38 +176,166 @@
             fallback.appendChild(switcherContainer);
         }
 
-        injectIntoNavigation();
+        ensureNavigationInjection();
         updateButtonStates();
     }
 
-    function injectIntoNavigation() {
-        var navigation = document.querySelector('#primary-menu, nav .primary-menu, nav[aria-label*="Primary" i] .menu, nav[aria-label*="Primary" i], .primary-menu');
-        if (!navigation) {
-            if (switcherContainer) {
-                switcherContainer.classList.remove('kls-switcher--nav');
-            }
+    function ensureNavigationInjection() {
+        if (!switcherContainer) {
             return;
         }
 
-        switcherContainer.classList.add('kls-switcher--nav');
-
-        var linkedInLink = navigation.querySelector('a[href*="linkedin.com" i]');
-        var linkedInItem = linkedInLink ? linkedInLink.closest('li') : null;
-        var containerWrapper;
-
-        if (linkedInItem && linkedInItem.parentNode) {
-            containerWrapper = document.createElement(linkedInItem.nodeName || 'li');
-            containerWrapper.className = (linkedInItem.className ? linkedInItem.className + ' ' : '') + 'kls-switcher__item';
-            containerWrapper.appendChild(switcherContainer);
-            linkedInItem.parentNode.insertBefore(containerWrapper, linkedInItem);
-        } else if (navigation.tagName && navigation.tagName.toLowerCase() === 'ul') {
-            containerWrapper = document.createElement('li');
-            containerWrapper.className = 'menu-item kls-switcher__item';
-            containerWrapper.appendChild(switcherContainer);
-            navigation.appendChild(containerWrapper);
-        } else {
-            navigation.appendChild(switcherContainer);
+        if (injectIntoNavigation()) {
+            return;
         }
+
+        if (!navigationObserver) {
+            try {
+                navigationObserver = new MutationObserver(function() {
+                    if (injectIntoNavigation()) {
+                        stopNavigationWatchers();
+                    }
+                });
+
+                navigationObserver.observe(document.body, { childList: true, subtree: true });
+            } catch (error) {
+                navigationObserver = null;
+            }
+        }
+
+        if (!navigationInterval) {
+            var attempts = 0;
+            navigationInterval = window.setInterval(function() {
+                attempts += 1;
+                if (injectIntoNavigation() || attempts >= 40) {
+                    stopNavigationWatchers();
+                }
+            }, 250);
+        }
+    }
+
+    function stopNavigationWatchers() {
+        if (navigationObserver) {
+            navigationObserver.disconnect();
+            navigationObserver = null;
+        }
+
+        if (navigationInterval) {
+            window.clearInterval(navigationInterval);
+            navigationInterval = null;
+        }
+    }
+
+    function ensureNavigationWrapper(tagName, additionalClasses) {
+        var normalizedTag = (tagName || '').toLowerCase() || 'div';
+
+        if (navigationWrapper && navigationWrapper.tagName.toLowerCase() !== normalizedTag) {
+            if (navigationWrapper.parentNode) {
+                navigationWrapper.parentNode.removeChild(navigationWrapper);
+            }
+            navigationWrapper = null;
+        }
+
+        if (!navigationWrapper) {
+            navigationWrapper = document.createElement(normalizedTag);
+            navigationWrapper.className = 'kls-switcher__item';
+        }
+
+        if (additionalClasses) {
+            additionalClasses.split(/\s+/).forEach(function(className) {
+                if (!className) {
+                    return;
+                }
+
+                if (!navigationWrapper.classList.contains(className)) {
+                    navigationWrapper.classList.add(className);
+                }
+            });
+        }
+
+        if (!navigationWrapper.classList.contains('kls-switcher__item')) {
+            navigationWrapper.classList.add('kls-switcher__item');
+        }
+
+        return navigationWrapper;
+    }
+
+    function injectIntoNavigation() {
+        if (!switcherContainer) {
+            return false;
+        }
+
+        var linkedInLink = document.querySelector('a[href*="linkedin.com" i]');
+        var referenceItem = linkedInLink ? linkedInLink.closest('li, .menu-item, .wp-block-navigation-item') : null;
+        var referenceParent = referenceItem && referenceItem.parentNode ? referenceItem.parentNode : null;
+
+        if (!referenceParent && linkedInLink && linkedInLink.parentNode) {
+            referenceParent = linkedInLink.parentNode;
+        }
+
+        if (referenceParent && document.body.contains(referenceParent)) {
+            var wrapperTag;
+            var wrapperClasses = '';
+
+            if (referenceItem && referenceItem.nodeName) {
+                wrapperTag = referenceItem.nodeName;
+                wrapperClasses = referenceItem.className || '';
+            } else if (referenceParent.nodeName) {
+                wrapperTag = referenceParent.nodeName;
+                wrapperClasses = referenceParent.className || '';
+            }
+
+            var wrapper = ensureNavigationWrapper(wrapperTag, wrapperClasses);
+
+            if (referenceItem && referenceItem.parentNode === referenceParent) {
+                if (wrapper.parentNode !== referenceParent || wrapper.nextSibling !== referenceItem) {
+                    referenceParent.insertBefore(wrapper, referenceItem);
+                }
+            } else if (referenceParent.firstChild) {
+                if (wrapper.parentNode !== referenceParent || wrapper !== referenceParent.firstChild) {
+                    referenceParent.insertBefore(wrapper, referenceParent.firstChild);
+                }
+            } else if (wrapper.parentNode !== referenceParent) {
+                referenceParent.appendChild(wrapper);
+            }
+
+            if (switcherContainer.parentNode !== wrapper) {
+                wrapper.appendChild(switcherContainer);
+            }
+
+            switcherContainer.classList.add('kls-switcher--nav');
+            return true;
+        }
+
+        var navigation = document.querySelector('#primary-menu, nav .primary-menu, nav[aria-label*="primary" i] ul, nav[aria-label*="primary" i] .menu, nav[aria-label*="navigation" i] ul, .primary-menu, .main-header-menu, .menu');
+
+        if (navigation && document.body.contains(navigation)) {
+            var fallbackWrapper;
+            if (navigation.tagName && navigation.tagName.toLowerCase() === 'ul') {
+                fallbackWrapper = ensureNavigationWrapper('li', 'menu-item');
+                if (fallbackWrapper.parentNode !== navigation) {
+                    navigation.appendChild(fallbackWrapper);
+                }
+            } else {
+                fallbackWrapper = ensureNavigationWrapper(navigation.nodeName, navigation.className || '');
+                if (fallbackWrapper.parentNode !== navigation) {
+                    navigation.appendChild(fallbackWrapper);
+                }
+            }
+
+            if (switcherContainer.parentNode !== fallbackWrapper) {
+                fallbackWrapper.appendChild(switcherContainer);
+            }
+
+            switcherContainer.classList.add('kls-switcher--nav');
+            return true;
+        }
+
+        if (switcherContainer) {
+            switcherContainer.classList.remove('kls-switcher--nav');
+        }
+
+        return false;
     }
 
     function init() {

--- a/wp-language-switcher/assets/js/translation-switcher.js
+++ b/wp-language-switcher/assets/js/translation-switcher.js
@@ -1,0 +1,220 @@
+(function() {
+    if (!window.KLSData || !document.body) {
+        return;
+    }
+
+    var settings = window.KLSData;
+    var originalHtmlLang = document.documentElement.getAttribute('lang') || settings.htmlLang || 'en';
+    var translations = settings.translations || {};
+    var normalizedTranslations = {};
+    var hasTranslations = false;
+
+    function normalize(value) {
+        return value.replace(/\s+/g, ' ').trim();
+    }
+
+    Object.keys(translations).forEach(function(key) {
+        var normalizedKey = normalize(String(key));
+        if (!normalizedKey) {
+            return;
+        }
+
+        normalizedTranslations[normalizedKey] = String(translations[key]);
+        hasTranslations = true;
+    });
+
+    if (!hasTranslations) {
+        return;
+    }
+
+    var language = (settings.defaultLanguage === 'es') ? 'es' : 'en';
+    var textNodes = [];
+
+    function collectTextNodes() {
+        var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+            acceptNode: function(node) {
+                if (!node || !node.nodeValue) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+
+                var parent = node.parentElement;
+                if (!parent) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+
+                if (parent.closest && parent.closest('.kls-switcher')) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+
+                var tag = parent.tagName ? parent.tagName.toLowerCase() : '';
+                if (tag === 'script' || tag === 'style' || tag === 'noscript' || tag === 'template') {
+                    return NodeFilter.FILTER_REJECT;
+                }
+
+                if (!node.nodeValue.trim()) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+
+                return NodeFilter.FILTER_ACCEPT;
+            }
+        });
+
+        var current;
+        while ((current = walker.nextNode())) {
+            var value = current.nodeValue;
+            var normalized = normalize(value);
+            if (!normalized) {
+                continue;
+            }
+
+            var translation = normalizedTranslations[normalized];
+            if (!translation) {
+                continue;
+            }
+
+            var leading = value.match(/^\s*/);
+            var trailing = value.match(/\s*$/);
+
+            textNodes.push({
+                node: current,
+                normalized: normalized,
+                original: value,
+                translation: translation,
+                leading: leading ? leading[0] : '',
+                trailing: trailing ? trailing[0] : ''
+            });
+        }
+    }
+
+    function setLanguage(nextLanguage) {
+        if (language === nextLanguage) {
+            return;
+        }
+
+        language = nextLanguage;
+        updateLanguage();
+    }
+
+    function updateLanguage() {
+        var useSpanish = language === 'es';
+
+        textNodes.forEach(function(entry) {
+            if (!entry.node || !entry.node.nodeValue) {
+                return;
+            }
+
+            if (useSpanish) {
+                entry.node.nodeValue = entry.leading + entry.translation + entry.trailing;
+            } else {
+                entry.node.nodeValue = entry.original;
+            }
+        });
+
+        if (language === 'es') {
+            document.documentElement.setAttribute('lang', 'es');
+        } else {
+            document.documentElement.setAttribute('lang', originalHtmlLang);
+        }
+
+        updateButtonStates();
+    }
+
+    var switcherContainer;
+    var englishButton;
+    var spanishButton;
+
+    function updateButtonStates() {
+        if (!englishButton || !spanishButton) {
+            return;
+        }
+
+        var activeClass = 'kls-switcher__button--active';
+        if (language === 'es') {
+            englishButton.classList.remove(activeClass);
+            spanishButton.classList.add(activeClass);
+            englishButton.setAttribute('aria-pressed', 'false');
+            spanishButton.setAttribute('aria-pressed', 'true');
+        } else {
+            spanishButton.classList.remove(activeClass);
+            englishButton.classList.add(activeClass);
+            spanishButton.setAttribute('aria-pressed', 'false');
+            englishButton.setAttribute('aria-pressed', 'true');
+        }
+    }
+
+    function createSwitcher() {
+        switcherContainer = document.createElement('div');
+        switcherContainer.className = 'kls-switcher';
+        switcherContainer.setAttribute('role', 'group');
+        switcherContainer.setAttribute('aria-label', 'Language selector');
+
+        englishButton = document.createElement('button');
+        englishButton.type = 'button';
+        englishButton.className = 'kls-switcher__button';
+        englishButton.textContent = settings.englishLabel || 'English';
+        englishButton.addEventListener('click', function() {
+            setLanguage('en');
+        });
+
+        spanishButton = document.createElement('button');
+        spanishButton.type = 'button';
+        spanishButton.className = 'kls-switcher__button';
+        spanishButton.textContent = settings.spanishLabel || 'Español';
+        spanishButton.addEventListener('click', function() {
+            setLanguage('es');
+        });
+
+        switcherContainer.appendChild(englishButton);
+        switcherContainer.appendChild(spanishButton);
+
+        var fallback = document.getElementById('kls-switcher-root');
+        if (fallback) {
+            fallback.removeAttribute('hidden');
+            fallback.appendChild(switcherContainer);
+        }
+
+        injectIntoNavigation();
+        updateButtonStates();
+    }
+
+    function injectIntoNavigation() {
+        var navigation = document.querySelector('#primary-menu, nav .primary-menu, nav[aria-label*="Primary" i] .menu, nav[aria-label*="Primary" i], .primary-menu');
+        if (!navigation) {
+            return;
+        }
+
+        var linkedInLink = navigation.querySelector('a[href*="linkedin.com" i]');
+        var linkedInItem = linkedInLink ? linkedInLink.closest('li') : null;
+        var containerWrapper;
+
+        if (linkedInItem && linkedInItem.parentNode) {
+            containerWrapper = document.createElement(linkedInItem.nodeName || 'li');
+            containerWrapper.className = (linkedInItem.className ? linkedInItem.className + ' ' : '') + 'kls-switcher__item';
+            containerWrapper.appendChild(switcherContainer);
+            linkedInItem.parentNode.insertBefore(containerWrapper, linkedInItem);
+        } else if (navigation.tagName && navigation.tagName.toLowerCase() === 'ul') {
+            containerWrapper = document.createElement('li');
+            containerWrapper.className = 'menu-item kls-switcher__item';
+            containerWrapper.appendChild(switcherContainer);
+            navigation.appendChild(containerWrapper);
+        } else {
+            navigation.appendChild(switcherContainer);
+        }
+    }
+
+    function init() {
+        collectTextNodes();
+        if (!textNodes.length) {
+            return;
+        }
+
+        createSwitcher();
+        updateLanguage();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Kovacic Language Switcher
  * Description: Adds a lightweight language switcher to individual pages and lets editors provide translations for on-page strings.
- * Version: 2.1.0
+ * Version: 2.1.1
  * Author: Kovacic Talent
  */
 
@@ -26,7 +26,7 @@ class Kovacic_Language_Switcher {
     }
 
     public function register_assets(): void {
-        $version = '2.1.0';
+        $version = '2.1.1';
         $base_url = plugin_dir_url(__FILE__);
 
         wp_register_style(

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Kovacic Language Switcher
  * Description: Adds a lightweight language switcher to individual pages and lets editors provide translations for on-page strings.
- * Version: 2.1.1
+ * Version: 2.1.2
  * Author: Kovacic Talent
  */
 
@@ -26,7 +26,7 @@ class Kovacic_Language_Switcher {
     }
 
     public function register_assets(): void {
-        $version = '2.1.1';
+        $version = '2.1.2';
         $base_url = plugin_dir_url(__FILE__);
 
         wp_register_style(

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Kovacic Language Switcher
  * Description: Adds a lightweight language switcher to individual pages and lets editors provide translations for on-page strings.
- * Version: 2.1.2
+ * Version: 2.1.3
  * Author: Kovacic Talent
  */
 
@@ -26,7 +26,7 @@ class Kovacic_Language_Switcher {
     }
 
     public function register_assets(): void {
-        $version = '2.1.2';
+        $version = '2.1.3';
         $base_url = plugin_dir_url(__FILE__);
 
         wp_register_style(

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * Plugin Name: Kovacic Language Switcher
+ * Description: Adds a lightweight language switcher to individual pages and lets editors provide translations for on-page strings.
+ * Version: 2.0.0
+ * Author: Kovacic Talent
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Kovacic_Language_Switcher {
+    private const META_KEY = '_kls_string_translations';
+
+    private ?array $current_settings = null;
+    private bool $portal_rendered = false;
+
+    public function __construct() {
+        add_action('init', [$this, 'register_assets']);
+        add_action('add_meta_boxes', [$this, 'register_meta_box']);
+        add_action('save_post_page', [$this, 'save_meta_box']);
+        add_action('template_redirect', [$this, 'prepare_frontend']);
+    }
+
+    public function register_assets(): void {
+        $version = '2.0.0';
+        $base_url = plugin_dir_url(__FILE__);
+
+        wp_register_style(
+            'kls-switcher',
+            $base_url . 'assets/css/translation-switcher.css',
+            [],
+            $version
+        );
+
+        wp_register_script(
+            'kls-switcher',
+            $base_url . 'assets/js/translation-switcher.js',
+            [],
+            $version,
+            true
+        );
+    }
+
+    public function register_meta_box(): void {
+        add_meta_box(
+            'kls_translation_box',
+            __('Language switcher – Spanish translation', 'kovacic-language-switcher'),
+            [$this, 'render_meta_box'],
+            'page',
+            'normal',
+            'default'
+        );
+    }
+
+    private function get_page_settings(int $post_id): array {
+        $saved = get_post_meta($post_id, self::META_KEY, true);
+        if (!is_array($saved)) {
+            return [];
+        }
+
+        $strings = [];
+        if (!empty($saved['strings']) && is_array($saved['strings'])) {
+            foreach ($saved['strings'] as $key => $value) {
+                $normalized = $this->normalize_string((string) $key);
+                if ($normalized === '') {
+                    continue;
+                }
+
+                $strings[$normalized] = sanitize_textarea_field($value);
+            }
+        }
+
+        return [
+            'enabled' => !empty($saved['enabled']),
+            'default_language' => in_array($saved['default_language'] ?? 'en', ['en', 'es'], true) ? $saved['default_language'] : 'en',
+            'english_label' => $saved['english_label'] ?? __('English', 'kovacic-language-switcher'),
+            'spanish_label' => $saved['spanish_label'] ?? __('Español', 'kovacic-language-switcher'),
+            'strings' => $strings,
+        ];
+    }
+
+    private function build_defaults(array $settings = []): array {
+        return [
+            'enabled' => !empty($settings['enabled']),
+            'default_language' => $settings['default_language'] ?? 'en',
+            'english_label' => $settings['english_label'] ?? __('English', 'kovacic-language-switcher'),
+            'spanish_label' => $settings['spanish_label'] ?? __('Español', 'kovacic-language-switcher'),
+            'strings' => is_array($settings['strings'] ?? null) ? $settings['strings'] : [],
+        ];
+    }
+
+    public function render_meta_box(\WP_Post $post): void {
+        $defaults = $this->build_defaults($this->get_page_settings($post->ID));
+        $strings = $this->collect_page_strings($post);
+
+        wp_nonce_field('kls_translation_box', 'kls_translation_nonce');
+        ?>
+        <p><?php esc_html_e('Provide the Spanish translation for the visible text on this page. The original page content is treated as English.', 'kovacic-language-switcher'); ?></p>
+        <p>
+            <label for="kls_switcher_enabled">
+                <input type="checkbox" id="kls_switcher_enabled" name="kls_switcher[enabled]" value="1" <?php checked($defaults['enabled']); ?> />
+                <?php esc_html_e('Enable the language switcher on this page', 'kovacic-language-switcher'); ?>
+            </label>
+        </p>
+        <p>
+            <label for="kls_default_language" class="screen-reader-text"><?php esc_html_e('Default language', 'kovacic-language-switcher'); ?></label>
+            <strong><?php esc_html_e('Default language shown to visitors', 'kovacic-language-switcher'); ?></strong>
+            <select name="kls_switcher[default_language]" id="kls_default_language">
+                <option value="en" <?php selected($defaults['default_language'], 'en'); ?>><?php echo esc_html($defaults['english_label']); ?></option>
+                <option value="es" <?php selected($defaults['default_language'], 'es'); ?>><?php echo esc_html($defaults['spanish_label']); ?></option>
+            </select>
+        </p>
+        <p>
+            <label for="kls_english_label"><?php esc_html_e('English label', 'kovacic-language-switcher'); ?></label><br />
+            <input type="text" id="kls_english_label" name="kls_switcher[english_label]" value="<?php echo esc_attr($defaults['english_label']); ?>" class="widefat" />
+        </p>
+        <p>
+            <label for="kls_spanish_label"><?php esc_html_e('Spanish label', 'kovacic-language-switcher'); ?></label><br />
+            <input type="text" id="kls_spanish_label" name="kls_switcher[spanish_label]" value="<?php echo esc_attr($defaults['spanish_label']); ?>" class="widefat" />
+        </p>
+        <h2><?php esc_html_e('Translations', 'kovacic-language-switcher'); ?></h2>
+        <?php if (empty($strings)) : ?>
+            <p class="description"><?php esc_html_e('No strings were detected for this page. Publish the page content first, then revisit this screen.', 'kovacic-language-switcher'); ?></p>
+        <?php else : ?>
+            <table class="widefat striped">
+                <thead>
+                    <tr>
+                        <th scope="col"><?php esc_html_e('Original text', 'kovacic-language-switcher'); ?></th>
+                        <th scope="col"><?php esc_html_e('Spanish translation', 'kovacic-language-switcher'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($strings as $string) :
+                    $hash = md5($string['normalized']);
+                    $saved_value = $defaults['strings'][$string['normalized']] ?? '';
+                    ?>
+                    <tr>
+                        <td>
+                            <strong><?php echo esc_html($string['display']); ?></strong>
+                            <?php if ($string['display'] !== $string['original']) : ?>
+                                <p class="description"><?php echo esc_html($string['original']); ?></p>
+                            <?php endif; ?>
+                            <input type="hidden" name="kls_switcher[string_map][<?php echo esc_attr($hash); ?>]" value="<?php echo esc_attr($string['normalized']); ?>" />
+                        </td>
+                        <td>
+                            <textarea name="kls_switcher[strings][<?php echo esc_attr($hash); ?>]" rows="2" class="widefat" placeholder="<?php esc_attr_e('Enter Spanish translation', 'kovacic-language-switcher'); ?>"><?php echo esc_textarea($saved_value); ?></textarea>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+        <?php
+    }
+
+    public function save_meta_box(int $post_id): void {
+        if (!isset($_POST['kls_translation_nonce']) || !wp_verify_nonce($_POST['kls_translation_nonce'], 'kls_translation_box')) {
+            return;
+        }
+
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+
+        if (!current_user_can('edit_page', $post_id)) {
+            return;
+        }
+
+        $raw = $_POST['kls_switcher'] ?? null;
+        if (!$raw) {
+            delete_post_meta($post_id, self::META_KEY);
+            return;
+        }
+
+        $this->persist_page_settings($post_id, $raw);
+    }
+
+    private function persist_page_settings(int $post_id, array $raw): void {
+        $raw = wp_unslash($raw);
+
+        $enabled = !empty($raw['enabled']);
+        $default_language = in_array($raw['default_language'] ?? 'en', ['en', 'es'], true) ? $raw['default_language'] : 'en';
+
+        $strings = [];
+        $string_map = $raw['string_map'] ?? [];
+        $translations = $raw['strings'] ?? [];
+
+        if (is_array($string_map) && is_array($translations)) {
+            foreach ($string_map as $hash => $original) {
+                $normalized = $this->normalize_string((string) $original);
+                if ($normalized === '' || !isset($translations[$hash])) {
+                    continue;
+                }
+
+                $translation = sanitize_textarea_field($translations[$hash]);
+                if ($translation === '') {
+                    continue;
+                }
+
+                $strings[$normalized] = $translation;
+            }
+        }
+
+        $data = [
+            'enabled' => $enabled,
+            'default_language' => $default_language,
+            'english_label' => sanitize_text_field($raw['english_label'] ?? __('English', 'kovacic-language-switcher')),
+            'spanish_label' => sanitize_text_field($raw['spanish_label'] ?? __('Español', 'kovacic-language-switcher')),
+            'strings' => $strings,
+        ];
+
+        if (!$enabled && empty($strings)) {
+            delete_post_meta($post_id, self::META_KEY);
+            return;
+        }
+
+        update_post_meta($post_id, self::META_KEY, $data);
+    }
+
+    public function prepare_frontend(): void {
+        if (!is_singular('page')) {
+            return;
+        }
+
+        $post_id = get_queried_object_id();
+        if (!$post_id) {
+            return;
+        }
+
+        $settings = $this->get_page_settings($post_id);
+        if (empty($settings) || empty($settings['enabled']) || empty($settings['strings'])) {
+            return;
+        }
+
+        $this->current_settings = $settings;
+
+        wp_enqueue_style('kls-switcher');
+        wp_enqueue_script('kls-switcher');
+
+        wp_localize_script('kls-switcher', 'KLSData', [
+            'defaultLanguage' => $this->current_settings['default_language'] ?? 'en',
+            'englishLabel' => $this->current_settings['english_label'] ?? __('English', 'kovacic-language-switcher'),
+            'spanishLabel' => $this->current_settings['spanish_label'] ?? __('Español', 'kovacic-language-switcher'),
+            'htmlLang' => get_bloginfo('language') ?: 'en',
+            'translations' => $this->current_settings['strings'],
+        ]);
+
+        add_action('wp_body_open', [$this, 'render_switcher_portal'], 5);
+    }
+
+    public function render_switcher_portal(): void {
+        if ($this->portal_rendered || empty($this->current_settings)) {
+            return;
+        }
+
+        $this->portal_rendered = true;
+        ?>
+        <div id="kls-switcher-root" class="kls-switcher-portal" hidden></div>
+        <?php
+    }
+
+    private function collect_page_strings(\WP_Post $post): array {
+        $content = $this->render_post_content($post);
+        if ($content === '') {
+            return [];
+        }
+
+        $document = new \DOMDocument();
+        libxml_use_internal_errors(true);
+        $html = function_exists('mb_convert_encoding') ? mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8') : $content;
+        $loaded = $document->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_NOWARNING | LIBXML_NOERROR);
+        libxml_clear_errors();
+
+        if (!$loaded) {
+            return [];
+        }
+
+        $xpath = new \DOMXPath($document);
+        $nodes = $xpath->query('//text()[normalize-space()]');
+
+        if (!$nodes || $nodes->length === 0) {
+            return [];
+        }
+
+        $strings = [];
+
+        /** @var \DOMText $node */
+        foreach ($nodes as $node) {
+            $parent = $node->parentNode;
+            if (!$parent instanceof \DOMElement) {
+                continue;
+            }
+
+            $tag = strtolower($parent->nodeName);
+            if (in_array($tag, ['script', 'style', 'noscript', 'template'], true)) {
+                continue;
+            }
+
+            $original = $node->nodeValue ?? '';
+            $normalized = $this->normalize_string($original);
+            if ($normalized === '') {
+                continue;
+            }
+
+            if (isset($strings[$normalized])) {
+                continue;
+            }
+
+            $display = trim(preg_replace('/\s+/u', ' ', $original));
+            if ($display === '') {
+                $display = $normalized;
+            }
+
+            $strings[$normalized] = [
+                'normalized' => $normalized,
+                'original' => $original,
+                'display' => $display,
+            ];
+        }
+
+        return array_values($strings);
+    }
+
+    private function render_post_content(\WP_Post $post): string {
+        $content = $post->post_content;
+        if (!is_string($content) || $content === '') {
+            return '';
+        }
+
+        $rendered = apply_filters('the_content', $content);
+        if (!is_string($rendered)) {
+            return '';
+        }
+
+        return $rendered;
+    }
+
+    private function normalize_string(string $value): string {
+        $charset = get_bloginfo('charset');
+        if (!is_string($charset) || $charset === '') {
+            $charset = 'UTF-8';
+        }
+
+        $decoded = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, $charset);
+        $collapsed = preg_replace('/\s+/u', ' ', (string) $decoded);
+
+        return trim((string) $collapsed);
+    }
+}
+
+new Kovacic_Language_Switcher();

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Kovacic Language Switcher
  * Description: Adds a lightweight language switcher to individual pages and lets editors provide translations for on-page strings.
- * Version: 2.1.4
+ * Version: 2.1.5
  * Author: Kovacic Talent
  */
 
@@ -26,7 +26,7 @@ class Kovacic_Language_Switcher {
     }
 
     public function register_assets(): void {
-        $version = '2.1.4';
+        $version = '2.1.5';
         $base_url = plugin_dir_url(__FILE__);
 
         wp_register_style(

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -331,8 +331,8 @@ class Kovacic_Language_Switcher {
 
         $english_setting = $this->current_settings['english_label'] ?? 'EN';
         $spanish_setting = $this->current_settings['spanish_label'] ?? 'ES';
-        $english_label = esc_html($is_nav ? 'EN' : $english_setting);
-        $spanish_label = esc_html($is_nav ? 'ES' : $spanish_setting);
+        $english_label = esc_html($this->get_switcher_label($english_setting, 'EN', 'en'));
+        $spanish_label = esc_html($this->get_switcher_label($spanish_setting, 'ES', 'es'));
         $group_label = __('Language selector', 'kovacic-language-switcher');
 
         ob_start();
@@ -344,6 +344,26 @@ class Kovacic_Language_Switcher {
         <?php
 
         return trim((string) ob_get_clean());
+    }
+
+    private function get_switcher_label($value, string $fallback, string $language_code): string {
+        $label = is_string($value) ? trim($value) : '';
+        if ($label === '') {
+            return $fallback;
+        }
+
+        if (function_exists('mb_strtoupper')) {
+            $label = mb_strtoupper($label, 'UTF-8');
+        } else {
+            $label = strtoupper($label);
+        }
+
+        $length = function_exists('mb_strlen') ? mb_strlen($label, 'UTF-8') : strlen($label);
+        if ($length > 3) {
+            $label = function_exists('mb_strtoupper') ? mb_strtoupper($language_code, 'UTF-8') : strtoupper($language_code);
+        }
+
+        return $label === '' ? $fallback : $label;
     }
 
     private function collect_page_strings(\WP_Post $post): array {

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Kovacic Language Switcher
  * Description: Adds a lightweight language switcher to individual pages and lets editors provide translations for on-page strings.
- * Version: 2.0.1
+ * Version: 2.1.0
  * Author: Kovacic Talent
  */
 
@@ -26,7 +26,7 @@ class Kovacic_Language_Switcher {
     }
 
     public function register_assets(): void {
-        $version = '2.0.1';
+        $version = '2.1.0';
         $base_url = plugin_dir_url(__FILE__);
 
         wp_register_style(
@@ -77,8 +77,8 @@ class Kovacic_Language_Switcher {
         return [
             'enabled' => !empty($saved['enabled']),
             'default_language' => in_array($saved['default_language'] ?? 'en', ['en', 'es'], true) ? $saved['default_language'] : 'en',
-            'english_label' => $saved['english_label'] ?? __('English', 'kovacic-language-switcher'),
-            'spanish_label' => $saved['spanish_label'] ?? __('Español', 'kovacic-language-switcher'),
+            'english_label' => $saved['english_label'] ?? 'EN',
+            'spanish_label' => $saved['spanish_label'] ?? 'ES',
             'strings' => $strings,
         ];
     }
@@ -87,8 +87,8 @@ class Kovacic_Language_Switcher {
         return [
             'enabled' => !empty($settings['enabled']),
             'default_language' => $settings['default_language'] ?? 'en',
-            'english_label' => $settings['english_label'] ?? __('English', 'kovacic-language-switcher'),
-            'spanish_label' => $settings['spanish_label'] ?? __('Español', 'kovacic-language-switcher'),
+            'english_label' => $settings['english_label'] ?? 'EN',
+            'spanish_label' => $settings['spanish_label'] ?? 'ES',
             'strings' => is_array($settings['strings'] ?? null) ? $settings['strings'] : [],
         ];
     }
@@ -208,8 +208,8 @@ class Kovacic_Language_Switcher {
         $data = [
             'enabled' => $enabled,
             'default_language' => $default_language,
-            'english_label' => sanitize_text_field($raw['english_label'] ?? __('English', 'kovacic-language-switcher')),
-            'spanish_label' => sanitize_text_field($raw['spanish_label'] ?? __('Español', 'kovacic-language-switcher')),
+            'english_label' => sanitize_text_field($raw['english_label'] ?? 'EN'),
+            'spanish_label' => sanitize_text_field($raw['spanish_label'] ?? 'ES'),
             'strings' => $strings,
         ];
 
@@ -329,14 +329,15 @@ class Kovacic_Language_Switcher {
         $english_active = $default === 'en';
         $spanish_active = $default === 'es';
 
-        $english_label = esc_html($this->current_settings['english_label'] ?? __('English', 'kovacic-language-switcher'));
-        $spanish_label = esc_html($this->current_settings['spanish_label'] ?? __('Español', 'kovacic-language-switcher'));
+        $english_setting = $this->current_settings['english_label'] ?? 'EN';
+        $spanish_setting = $this->current_settings['spanish_label'] ?? 'ES';
+        $english_label = esc_html($is_nav ? 'EN' : $english_setting);
+        $spanish_label = esc_html($is_nav ? 'ES' : $spanish_setting);
         $group_label = __('Language selector', 'kovacic-language-switcher');
 
         ob_start();
         ?>
         <div class="kls-switcher<?php echo $is_nav ? ' kls-switcher--nav' : ''; ?>" role="group" aria-label="<?php echo esc_attr($group_label); ?>">
-            <span class="kls-switcher__indicator" aria-hidden="true"></span>
             <button type="button" class="kls-switcher__button<?php echo $english_active ? ' kls-switcher__button--active' : ''; ?>" data-language="en" aria-pressed="<?php echo $english_active ? 'true' : 'false'; ?>"><?php echo $english_label; ?></button>
             <button type="button" class="kls-switcher__button<?php echo $spanish_active ? ' kls-switcher__button--active' : ''; ?>" data-language="es" aria-pressed="<?php echo $spanish_active ? 'true' : 'false'; ?>"><?php echo $spanish_label; ?></button>
         </div>

--- a/wp-language-switcher/language-switcher.php
+++ b/wp-language-switcher/language-switcher.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Kovacic Language Switcher
  * Description: Adds a lightweight language switcher to individual pages and lets editors provide translations for on-page strings.
- * Version: 2.1.3
+ * Version: 2.1.4
  * Author: Kovacic Talent
  */
 
@@ -26,7 +26,7 @@ class Kovacic_Language_Switcher {
     }
 
     public function register_assets(): void {
-        $version = '2.1.3';
+        $version = '2.1.4';
         $base_url = plugin_dir_url(__FILE__);
 
         wp_register_style(


### PR DESCRIPTION
## Summary
- replace the HTML paste workflow with per-string translation inputs inside the page editor meta box
- persist normalized string translations and expose them to the front-end toggle rendered beside the LinkedIn menu item
- simplify the JavaScript/CSS to swap detected text nodes in place while keeping the existing markup and interactivity intact

## Testing
- php -l wp-language-switcher/language-switcher.php

------
https://chatgpt.com/codex/tasks/task_e_68ccbf7ca568832abc400070646df70e